### PR TITLE
#56 Fix for strip quotes

### DIFF
--- a/includes/libft/Makefile
+++ b/includes/libft/Makefile
@@ -39,6 +39,7 @@ LIB_STRING = ft_strlcpy.c \
 			ft_strtrim.c \
 			ft_str_insert.c \
 			ft_str_remove.c \
+			ft_str_remove_char.c \
 
 LIB_APPLY = ft_strmapi.c \
 			ft_striteri.c \

--- a/includes/libft/includes/libft.h
+++ b/includes/libft/includes/libft.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/10/20 10:01:20 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/03/20 19:16:44 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 20:04:43 by quentinbeuk   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ void		*ft_realloc(void *ptr, size_t size);
 
 // String
 char		*ft_str_insert(char *base, char *insert, int i);
+char		*ft_str_remove_char(char *str, int i, char c);
 char		*ft_str_remove(char *base_input, const char *remove);
 size_t		ft_strlcpy(char *dst, const char *src, size_t dstsize);
 size_t		ft_strlcat(char *dst, const char *src, size_t dstsize);

--- a/includes/libft/lib_string/ft_str_remove.c
+++ b/includes/libft/lib_string/ft_str_remove.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/17 11:11:34 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/29 21:41:29 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 20:02:20 by quentinbeuk   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ static int	locate_substring(char *base_input, const char *needle)
 	return (i);
 }
 
-static char	*buffer_trailing_string(char *base_input, int remove_len, int i)
+char	*buffer_trailing_string(char *base_input, int remove_len, int i)
 {
 	int		j;
 	char	*buffer;
@@ -45,7 +45,7 @@ static char	*buffer_trailing_string(char *base_input, int remove_len, int i)
 	return (buffer);
 }
 
-static char	*insert_buffer(char *base_input, char *buffer, int i)
+char	*insert_buffer(char *base_input, char *buffer, int i)
 {
 	int		j;
 

--- a/includes/libft/lib_string/ft_str_remove_char.c
+++ b/includes/libft/lib_string/ft_str_remove_char.c
@@ -1,0 +1,65 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_str_remove_char.c                               :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2024/04/04 19:56:47 by quentinbeuk   #+#    #+#                 */
+/*   Updated: 2024/04/04 20:06:24 by quentinbeuk   ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../includes/libft.h"
+
+static char	*buffer_trailing_string(char *base_input, int remove_len, int i)
+{
+	int		j;
+	char	*buffer;
+
+	j = 0;
+	buffer = malloc(sizeof(char *) * ft_strlen(base_input));
+	if (buffer == NULL)
+		return (NULL);
+	while (base_input[i + remove_len])
+	{
+		buffer[j] = base_input[i + remove_len];
+		j++;
+		i++;
+	}
+	buffer[j] = '\0';
+	return (buffer);
+}
+
+static char	*insert_buffer(char *base_input, char *buffer, int i)
+{
+	int		j;
+
+	j = 0;
+	while (buffer[j])
+	{
+		base_input[i] = buffer[j];
+		i++;
+		j++;
+	}
+	base_input[i] = '\0';
+	return (base_input);
+}
+
+char	*ft_str_remove_char(char *str, int i, char c)
+{
+	char	*buffer;
+
+	if (str[i] != c)
+		return (str);
+
+	buffer = buffer_trailing_string(str, 1, i);
+	if (buffer == NULL)
+		return (NULL);
+	
+	str = insert_buffer(str, buffer, i);
+	free (buffer);
+
+	ft_realloc(str, ft_strlen(str));
+	return (str);
+}

--- a/sources/parser/parser_strip_quotes.c
+++ b/sources/parser/parser_strip_quotes.c
@@ -6,38 +6,51 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/24 09:51:56 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/29 22:02:25 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 21:03:04 by quentinbeuk   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static char *char_to_string(char c)
+static int next_quote_char(char *arg, int i, int quote_char)
 {
-	char *str;
-
-	str = safe_malloc(sizeof(char *) * 2);
-	str[0] = c;
-	str[1] = '\0';
-	return (str);
-}
-
-static char *strip_quotes_forward(char *arg, int quote_char)
-{
-	int		i;
 	int		len;
-	char	*quote_str;
 
-	i = 0;
+	i++;
 	len = ft_strlen(arg);
 	while (i < len)
 	{
 		if (arg[i] == quote_char)
+			return (i);
+		i++;
+	}
+	return (i);
+}
+
+static char *strip_quotes(char *arg)
+{
+	int		i;
+	int		len;
+	int		quote_type;
+
+	i = 0;
+	len = ft_strlen(arg);
+	
+	while (i < len)
+	{
+		if (is_quote(arg[i]))
 		{
-			quote_str = char_to_string(quote_char);
-			arg = ft_str_remove(arg,  quote_str);
-			free(quote_str);
+			quote_type = is_quote(arg[i]);
+			arg = ft_str_remove_char(arg, i, quote_type);
 			i--;
+
+			i = next_quote_char(arg, i, quote_type);
+			
+			if (is_quote(arg[i]) == quote_type)
+				arg = ft_str_remove_char(arg, i, quote_type);
+			
+			i--;
+			len = ft_strlen(arg);
 		}
 		i++;
 	}
@@ -46,6 +59,6 @@ static char *strip_quotes_forward(char *arg, int quote_char)
 
 char	*strip_quote_for_type(char *arg, int quote_char)
 {
-	arg = strip_quotes_forward(arg, quote_char);
+	arg = strip_quotes(arg);
 	return (arg);
 }

--- a/tests/test_commands.txt
+++ b/tests/test_commands.txt
@@ -59,7 +59,7 @@ echo "hello $TERM$NOARG more"
 echo $$$$$???
 echo 123$????
 echo hello$?
-echo hel'll"o"'
+echo hel'll"o"'						<-
 echo hello"more more"hello
 echo "hello $USER$TERM more"
 echo "hello $USER more"
@@ -67,6 +67,8 @@ echo hello$USER
 echo "hello $NOT_A_KEY"
 echo "my name is $USER and I use $TERM"
 echo "hello '$USER' more"
+echo ''"hello"
+echo ''"hello"''"there"
 
 
 === ERROR MESSAGES ===


### PR DESCRIPTION
* Fixed quotes strip quotes -> quotes outside of quotes.

e.g. `echo ''"hello"''"there"` = `hellothere`
e.g. `echo hel'll"o"'` = `helll"o"`