### PR TITLE
58 fix memory leaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: qbeukelm <qbeukelm@student.42.fr>            +#+                      #
 #                                                    +#+                       #
 #    Created: 2023/12/03 13:06:57 by quentinbeuk   #+#    #+#                  #
-#    Updated: 2024/04/04 21:08:39 by robertrinh    ########   odam.nl          #
+#    Updated: 2024/04/04 22:44:08 by robertrinh    ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: qbeukelm <qbeukelm@student.42.fr>            +#+                      #
 #                                                    +#+                       #
 #    Created: 2023/12/03 13:06:57 by quentinbeuk   #+#    #+#                  #
-#    Updated: 2024/04/04 20:45:55 by robertrinh    ########   odam.nl          #
+#    Updated: 2024/04/04 21:08:39 by robertrinh    ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: qbeukelm <qbeukelm@student.42.fr>            +#+                      #
 #                                                    +#+                       #
 #    Created: 2023/12/03 13:06:57 by quentinbeuk   #+#    #+#                  #
-#    Updated: 2024/03/29 22:16:28 by quentinbeuk   ########   odam.nl          #
+#    Updated: 2024/04/04 20:45:55 by robertrinh    ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 
@@ -124,7 +124,7 @@ LIBFT				= includes/libft
 
 # ===== Compile =====
 CC 					= cc -g
-CFLAGS 				= # -Wall -Werror -Wextra -g -fsanitize=address
+CFLAGS 				= -Wall -Werror -Wextra -g -fsanitize=address
 
 READLINE_LOC		=	~/.brew/opt/readline
 READLINE_LIB		=	-L $(READLINE_LOC)/lib -lreadline

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:15:00 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/04/03 21:59:57 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 20:43:52 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -167,7 +167,7 @@ typedef struct	s_shell
 	t_token				*tokens;
 	t_cmd_table			*cmd_table;
 	char				**envp;
-	char const			*input;
+	char				*input;
 	int					single_quote;
 	int					double_quote;
 	bool				print_output;
@@ -276,47 +276,47 @@ int		new_process(t_shell *shell, int i, t_pipes *pipes);
 int		execute(t_shell *shell);
 
 // ----------------------------------- executor/builtins
-typedef struct s_builtin_entry
-{
-    char	*name;
-    int		(*function)(t_cmd*, t_shell*);
-} t_builtin_entry;
+// typedef struct s_builtin_entry
+// {
+//     char	*name;
+//     int		(*function)(t_cmd*, t_shell*);
+// } t_builtin_entry;
 
 // builtins.c
-bool	is_single_builtin(char *cmd_value);
-int		exec_single_builtin(t_cmd *cmd, t_shell *shell);
-bool	is_builtin(char *cmd);
+bool	is_special_builtin(char *cmd_value);
+int		exec_special_builtin(t_cmd *cmd, t_shell *shell);
+bool	is_builtin(char *cmd_value);
 int		exec_builtin(t_cmd *cmd, t_shell *shell);
 
 // cd.c
 int		cd(t_cmd *cmd, t_shell *shell);
 
 // echo.c
-int		echo(t_cmd *cmd, t_shell *shell);
+int		echo(t_cmd *cmd);
 
 // env.c
-int		env(t_cmd *cmd, t_shell *shell);
+int		env(t_shell *shell);
 
 // exit.c
-int		exit_shell(t_cmd *cmd, t_shell *shell);
+int		exit_shell(t_cmd *cmd);
 
 // export.c
 int		export(t_cmd *cmd, t_shell *shell);
 
 // pwd.c
-int		pwd(t_cmd *cmd, t_shell *shell);
+int		pwd(void);
 
 // unset.c
 int		unset(t_cmd *cmd, t_shell *shell);
 
-static const t_builtin_entry builtin_table[] = {
-    {"echo", echo},
-    {"pwd", pwd},
-	{"export", export},
-	{"unset", unset},
-	{"env", env},
-	{"exit", exit_shell},
-};
+// static const t_builtin_entry builtin_table[] = {
+//     {"echo", echo},
+//     {"pwd", pwd},
+// 	{"export", export},
+// 	{"unset", unset},
+// 	{"env", env},
+// 	{"exit", exit_shell},
+// };
 
 // ----------------------------------- executor/command
 // execute_commands.c
@@ -376,7 +376,7 @@ void	rl_replace_line(const char *text, int clear_undo);
 char	*will_expand(char **env, char *arg);
 
 // get_env_key.c
-char	*get_env_key(char *arg, int i);
+char	*get_env_key(char *arg, size_t i);
 
 
 //===============================================================: Utils

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/01 14:47:56 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/04/04 17:41:56 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 22:37:54 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,9 @@ bool is_builtin(char *cmd_value)
 {
 	if (cmd_value == NULL)
 		return (false);
-	if (ft_strncmp(cmd_value, "echo", 5) == 0)
+	if (is_special_builtin(cmd_value))
+		return (true);
+	else if (ft_strncmp(cmd_value, "echo", 5) == 0)
 		return (true);
 	else if (ft_strncmp(cmd_value, "env", 4) == 0)
 		return (true);
@@ -55,10 +57,12 @@ bool is_builtin(char *cmd_value)
 }
 int	exec_builtin(t_cmd *cmd, t_shell *shell)
 {
+	if (is_special_builtin(cmd->value))
+		exit(0);
 	if (ft_strncmp(cmd->value, "echo", 5) == 0)
 		g_exit_code = echo(cmd);
 	else if (ft_strncmp(cmd->value, "env", 3) == 0)
-		g_exit_code = cd(cmd, shell);
+		g_exit_code = env(shell);
 	else if (ft_strncmp(cmd->value, "pwd", 7) == 0)
 		g_exit_code = pwd();
 	return (g_exit_code);

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -6,13 +6,13 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/01 14:47:56 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/04/03 22:15:00 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 17:41:56 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-bool	is_single_builtin(char *cmd_value)
+bool	is_special_builtin(char *cmd_value)
 {
 	if (cmd_value == NULL)
 		return (false);
@@ -28,10 +28,10 @@ bool	is_single_builtin(char *cmd_value)
 }
 
 // * change later with jump table
-int exec_single_builtin(t_cmd *cmd, t_shell *shell)
+int exec_special_builtin(t_cmd *cmd, t_shell *shell)
 {
 	if (ft_strncmp(cmd->value, "exit", 5) == 0)
-		g_exit_code = exit_shell(cmd, shell);
+		g_exit_code = exit_shell(cmd);
 	else if (ft_strncmp(cmd->value, "cd", 3) == 0)
 		g_exit_code = cd(cmd, shell);
 	else if (ft_strncmp(cmd->value, "export", 7) == 0)
@@ -41,36 +41,58 @@ int exec_single_builtin(t_cmd *cmd, t_shell *shell)
 	return (g_exit_code);
 }
 
-bool	is_builtin(char *cmd_value)
+bool is_builtin(char *cmd_value)
 {
-	int	i;
-
-	i = 0;
-	while (i < S_NUM_BUILTIN)
-	{
-		if (ft_strncmp(cmd_value, builtin_table[i].name, ft_strlen(builtin_table[i].name)) == 0)
-			return (true);
-		i++;
-	}
+	if (cmd_value == NULL)
+		return (false);
+	if (ft_strncmp(cmd_value, "echo", 5) == 0)
+		return (true);
+	else if (ft_strncmp(cmd_value, "env", 4) == 0)
+		return (true);
+	else if (ft_strncmp(cmd_value, "pwd", 4) == 0)
+		return (true);
 	return (false);
 }
-
 int	exec_builtin(t_cmd *cmd, t_shell *shell)
 {
-	int	i;
-
-	i = 0;
-	if (is_single_builtin(cmd->value))
-		exit(0);
-	while (i < S_NUM_BUILTIN)
-	{
-
-		if (ft_strncmp(cmd->value, builtin_table[i].name, ft_strlen(cmd->value)) == 0)
-		{
-			g_exit_code = builtin_table[i].function(cmd, shell);
-			return (g_exit_code);
-		}
-		i++;
-	}
-	return (1);
+	if (ft_strncmp(cmd->value, "echo", 5) == 0)
+		g_exit_code = echo(cmd);
+	else if (ft_strncmp(cmd->value, "env", 3) == 0)
+		g_exit_code = cd(cmd, shell);
+	else if (ft_strncmp(cmd->value, "pwd", 7) == 0)
+		g_exit_code = pwd();
+	return (g_exit_code);
 }
+// bool	is_builtin(char *cmd_value)
+// {
+// 	int	i;
+
+// 	i = 0;
+// 	while (i < S_NUM_BUILTIN)
+// 	{
+// 		if (ft_strncmp(cmd_value, builtin_table[i].name, ft_strlen(builtin_table[i].name)) == 0)
+// 			return (true);
+// 		i++;
+// 	}
+// 	return (false);
+// }
+
+// int	exec_builtin(t_cmd *cmd, t_shell *shell)
+// {
+// 	int	i;
+
+// 	i = 0;
+// 	if (is_single_builtin(cmd->value))
+// 		exit(0); // ! you still need to be able to exec command but give error / do nothing, not exit.
+// 	while (i < S_NUM_BUILTIN)
+// 	{
+
+// 		if (ft_strncmp(cmd->value, builtin_table[i].name, ft_strlen(cmd->value)) == 0)
+// 		{
+// 			g_exit_code = builtin_table[i].function(cmd, shell);
+// 			return (g_exit_code);
+// 		}
+// 		i++;
+// 	}
+// 	return (1);
+// }

--- a/sources/builtins/cd.c
+++ b/sources/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 14:31:20 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/03/28 18:26:35 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 16:47:09 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ static void	set_home_directory(t_cmd *cmd, t_shell *shell)
 int	cd(t_cmd *cmd, t_shell *shell)
 {
 	char	cwd[1024];
-	char	**path;
+	// char	**path;
 	
 	getcwd(cwd, 1024);
 	printf("cwd: %s\n", cwd);

--- a/sources/builtins/echo.c
+++ b/sources/builtins/echo.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/07 14:45:13 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/03/20 19:10:14 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 17:37:42 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ static void	print_echo(t_cmd *cmd, bool flag)
 		write(1, "\n", 1);
 }
 
-int	echo(t_cmd *cmd, t_shell *shell)
+int	echo(t_cmd *cmd)
 {
 	bool	flag;
 

--- a/sources/builtins/env.c
+++ b/sources/builtins/env.c
@@ -6,13 +6,13 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/07 14:45:44 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/03/20 19:12:23 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 17:38:23 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-int	env(t_cmd *cmd, t_shell *shell)
+int	env(t_shell *shell)
 {
 	int		i;
 	char	**envp;

--- a/sources/builtins/exit.c
+++ b/sources/builtins/exit.c
@@ -6,19 +6,19 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/03 09:41:20 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/04/03 22:17:21 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 17:41:40 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static void	arg_error(t_shell *shell)
+static void	arg_error(void)
 {
 	g_exit_code = EXIT_FAILURE;
 	ft_putstr_fd("minishell: exit: too many arguments\n", STDERR_FILENO);
 }
 
-static void	numeric_error(t_shell *shell, char *str)
+static void	numeric_error(char *str)
 {
 	g_exit_code = 2;
 	ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
@@ -42,15 +42,15 @@ static bool	ft_isnumber(char *str)
 	return (true);
 }
 
-int	exit_shell(t_cmd *cmd, t_shell *shell)
+int	exit_shell(t_cmd *cmd)
 {
 	// ft_putstr_fd("exit\n", STDOUT_FILENO);
 	if (cmd->arg_count > 1)
-		arg_error(shell);
+		arg_error();
 	if (cmd->arg_count == 1)
 	{
 		if (ft_isnumber(cmd->args[0]) == false || ft_strlen(cmd->args[0]) > 19)
-			numeric_error(shell, cmd->args[0]);
+			numeric_error(cmd->args[0]);
 		else
 			g_exit_code = ft_atoi(cmd->args[0]) % 256;
 	}

--- a/sources/builtins/pwd.c
+++ b/sources/builtins/pwd.c
@@ -6,13 +6,13 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/01 18:57:33 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/03/22 18:31:30 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 17:37:17 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-int	pwd(t_cmd *cmd, t_shell *shell)
+int	pwd(void)
 {
 	char	*buf;
 

--- a/sources/executor/command/execute_commands.c
+++ b/sources/executor/command/execute_commands.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 15:22:01 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/03/28 17:38:18 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 17:46:13 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ void	execute_command(t_shell *shell, int i)
 int	execute_commands(t_shell *shell)
 {
     int	i;
-	int	exit_status;
+	// int	exit_status;
 	t_pipes	*pipes;
 	
 	i = 0;

--- a/sources/executor/command/execute_commands.c
+++ b/sources/executor/command/execute_commands.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 15:22:01 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/04/04 17:46:13 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 22:27:24 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,13 @@ void	execute_command(t_shell *shell, int i)
 
 	cmd_path = shell->cmd_table->cmds[i]->cmd_path;
 	formatted_cmd = shell->cmd_table->cmds[i]->formatted_cmd;
-
-	execve(cmd_path, formatted_cmd, shell->envp); // TODO protec
+	
+	printf("cmd_path is %s\n", cmd_path);
+	printf("formatted_cmd is %s\n", formatted_cmd[0]);
+	if (execve(cmd_path, formatted_cmd, shell->envp) == -1)
+	{
+		printf("execve failed\n"); // TODO protec
+	}
 }
 
 

--- a/sources/executor/command/single_command.c
+++ b/sources/executor/command/single_command.c
@@ -6,19 +6,15 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 14:28:14 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/04/04 20:39:38 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 22:35:26 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
-
-
 
 #include "../../../includes/minishell.h"
 
 static t_validation	assign_out_redirects(t_cmd *cmd)
 {
 	t_validation	validation;
-	// int 			*fd_ins; // ? unused
-	// int				*fd_heredocs; // ? unused
 
 	validation = SUCCESS;
 	if (cmd->fd_out)
@@ -48,7 +44,7 @@ int	single_command(t_shell *shell)
 	pid_t			pid;
 	int				exit_status;
 
-	(void)validation;
+	// (void)validation;
 	handle_signals(CHILD);
 	redirect_in_files(shell->cmd_table->cmds[0]);
 	pid = fork();
@@ -60,6 +56,7 @@ int	single_command(t_shell *shell)
 		validation = child_process(shell);
 	else if (pid > 0)
 		waitpid(pid, &exit_status, 0);
+	printf("validation is: %d\n", validation);
 	if (WIFEXITED(exit_status))
 		return (WEXITSTATUS(exit_status));
 	return(WEXITSTATUS(g_exit_code));

--- a/sources/executor/command/single_command.c
+++ b/sources/executor/command/single_command.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 14:28:14 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/04/03 22:08:19 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 20:39:38 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,8 +17,8 @@
 static t_validation	assign_out_redirects(t_cmd *cmd)
 {
 	t_validation	validation;
-	int 			*fd_ins;
-	int				*fd_heredocs;
+	// int 			*fd_ins; // ? unused
+	// int				*fd_heredocs; // ? unused
 
 	validation = SUCCESS;
 	if (cmd->fd_out)
@@ -48,9 +48,9 @@ int	single_command(t_shell *shell)
 	pid_t			pid;
 	int				exit_status;
 
+	(void)validation;
 	handle_signals(CHILD);
 	redirect_in_files(shell->cmd_table->cmds[0]);
-	
 	pid = fork();
 	if (pid == -1)
 	{

--- a/sources/executor/executor.c
+++ b/sources/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 19:16:50 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/04/04 17:43:37 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 22:32:25 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,10 +19,7 @@ int		execute(t_shell *shell)
 	if (shell->cmd_table->cmd_count == 1)
 	{
 		if (is_special_builtin(shell->cmd_table->cmds[0]->value))
-		{
-			printf("is builtin\n");
 			exec_special_builtin(shell->cmd_table->cmds[0], shell);
-		}
 		else
 			g_exit_code = single_command(shell);
 	}

--- a/sources/executor/executor.c
+++ b/sources/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 19:16:50 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/04/03 22:15:29 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 17:43:37 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,10 +18,10 @@ int		execute(t_shell *shell)
 
 	if (shell->cmd_table->cmd_count == 1)
 	{
-		if (is_single_builtin(shell->cmd_table->cmds[0]->value))
+		if (is_special_builtin(shell->cmd_table->cmds[0]->value))
 		{
 			printf("is builtin\n");
-			exec_single_builtin(shell->cmd_table->cmds[0], shell);
+			exec_special_builtin(shell->cmd_table->cmds[0], shell);
 		}
 		else
 			g_exit_code = single_command(shell);

--- a/sources/executor/executor_enviroment.c
+++ b/sources/executor/executor_enviroment.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 19:45:47 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/28 18:08:12 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 22:28:39 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,10 @@ char	*get_path_for_cmd(char **env_paths, char *command)
 		temp_path = ft_strjoin(env_paths[i], "/"); // TODO protect + error
 		command_path = ft_strjoin(temp_path, command); // TODO protect + error
 		if (access(command_path, F_OK) == 0)
+		{
+			printf("acces is ok, command path is %s\n", command_path);
 			return (command_path);
+		}
 		i++;
 	}
 	return (NULL);

--- a/sources/executor/redirects/redirect_heredoc.c
+++ b/sources/executor/redirects/redirect_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/25 11:15:17 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/04/03 22:37:30 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 20:40:08 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 static bool is_eof(char *line, char *eof)
 {
-	int		eof_len;
+	size_t	eof_len;
 
 	eof_len = ft_strlen(eof);
 	if (ft_strlen(line) != eof_len)

--- a/sources/executor/redirects/redirect_in_files.c
+++ b/sources/executor/redirects/redirect_in_files.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/24 22:08:44 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/04/03 21:59:41 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 21:32:56 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,10 +59,13 @@ static void dup_infile(t_cmd *cmd, t_in_files *ins, t_redirect_type type)
 	int		index;
 
 	index = count_files_for_type(cmd, type) - 1;
-	if (type == IN_APPEND)
-		dup_for_fd(ins->heredocs[index]);
-	else if (type == IN)
-		dup_for_fd(ins->infiles[index]);
+	if (index >= 0)
+	{
+		if (type == IN_APPEND)
+			dup_for_fd(ins->heredocs[index]);
+		else if (type == IN)
+			dup_for_fd(ins->infiles[index]);
+	}
 }
 
 t_validation	redirect_in_files(t_cmd *cmd)

--- a/sources/expander/expander.c
+++ b/sources/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 11:15:41 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/29 22:23:43 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 20:42:40 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ static int	count_expand(char *arg)
 	return (count);
 }
 
-static char *expand_exit_code(char *arg, char *key, int i)
+static char *expand_exit_code(char *arg, char *key, size_t i)
 {
 	key = ft_strjoin("$", key);
 	arg = ft_str_remove(arg, key);
@@ -36,7 +36,7 @@ static char *expand_exit_code(char *arg, char *key, int i)
 	return (arg);
 }
 
-static char	*expand_arg(char **env, char *arg, int i)
+static char	*expand_arg(char **env, char *arg, size_t i)
 {
 	char	*key;
 	char	*value;
@@ -65,7 +65,7 @@ static char	*expand_arg(char **env, char *arg, int i)
 // TODO protect str_remove() & str_insert() 
 char	*will_expand(char **env, char *arg)
 {
-	int		i;
+	size_t	i;
 	int		expand_count;
 	int		expanded_count;
 

--- a/sources/expander/get_env_key.c
+++ b/sources/expander/get_env_key.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/29 22:10:43 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/29 22:16:45 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 20:43:10 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ static bool is_end_env_key(char c)
 	return (false);
 }
 
-static char *skip_multiple_expand_chars(char *arg, int i)
+static char *skip_multiple_expand_chars(char *arg, size_t i)
 {
 	int		j;
 	int		k;
@@ -49,7 +49,7 @@ static char *skip_multiple_expand_chars(char *arg, int i)
 	return (arg);
 }
 
-char	*get_env_key(char *arg, int i)
+char	*get_env_key(char *arg, size_t i)
 {
 	int		j;
 	char	*key;
@@ -61,7 +61,7 @@ char	*get_env_key(char *arg, int i)
 	
 	if (ft_strlen(arg) == i + 1)
 		return (arg);
-	
+
 	j = 0;
 	key = safe_malloc(sizeof(char *) * ft_strlen(arg) + 1);
 	while (arg[i])

--- a/sources/lexer/post_lexer.c
+++ b/sources/lexer/post_lexer.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/12 16:19:25 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/03/24 16:51:22 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 22:18:01 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/sources/lexer/split/split.c
+++ b/sources/lexer/split/split.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/05 14:17:27 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/03/24 09:05:31 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 21:06:22 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,25 +61,18 @@ static int	count_substrings(t_split *sp)
 char	**split(t_shell *shell)
 {
 	t_split		*split;
+	char		**split_string;
 
 	split = safe_malloc(sizeof(t_split));
 	split = init_split(shell, split);
-
-	// 1. Count substrings
 	split->count = count_substrings(split);
-
-	// 2. Malloc substring for count
 	split->strings = ft_calloc(sizeof(char *), (split->count + 1));
 	if (split->strings == NULL)
 	{
 		// TODO clean_exit()
 	}
-
-	// 3. Assign strings
 	split->strings = allocate_strings_split(split);
-
+	split_string = split->strings;
 	free(split);
-
-	// 4. Free split struct
-	return (split->strings);
+	return (split_string);
 }

--- a/sources/lexer/split/split_utils.c
+++ b/sources/lexer/split/split_utils.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/17 15:59:08 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/01/17 16:07:56 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 16:45:05 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 bool	is_white_space(char c)
 {
-	if (c >= 9 && c <= 13 || c == 32)
+	if ((c >= 9 && c <= 13) || c == 32)
 		return (true);
 	return (false);
 }

--- a/sources/minishell.c
+++ b/sources/minishell.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:13:49 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/04/03 22:39:45 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 16:44:15 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,11 @@ static bool	run(t_shell *shell)
 	{
 		handle_signals(PARENT);
 		retrieve_command(shell);
+		if (shell->input[0] == '\0')
+		{
+			free(shell->input);
+			continue ;
+		}
 		if (lexer_manager(shell) == SUCCESS)
 		{
 			finish_lexer(shell);
@@ -53,6 +58,7 @@ int	main(int argc, char **argv, char **envp)
 {
 	t_shell	*shell;
 
+	(void) argc;
 	shell = shell_init(envp, argv);
 	run(shell);
 	return (EXIT_SUCCESS);

--- a/sources/parser/parser.c
+++ b/sources/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/11 19:53:12 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/24 16:51:31 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 16:46:10 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,6 @@ bool	build_cmds(t_parse *p)
 
 bool	parse(t_shell *shell)
 {
-	t_cmd	**cmds;
 	t_parse	*p;
 
 	should_print("\n\n========parser========\n", shell->print_output);

--- a/sources/parser/parser_redirects.c
+++ b/sources/parser/parser_redirects.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/21 20:55:56 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/28 17:00:08 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 16:45:45 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ static bool		should_add_files(t_token_type current_type, t_token_type type)
 	return (false);
 }
 
-static t_redirect	*redirects_for_type(t_cmd *cmd, t_parse *p, t_token_type type)
+static t_redirect	*redirects_for_type(t_parse *p, t_token_type type)
 {
 	t_redirect	*files;
 	t_redirect	*files_head;
@@ -87,7 +87,7 @@ static t_redirect	*redirects_for_type(t_cmd *cmd, t_parse *p, t_token_type type)
 
 t_cmd	*construct_redirects(t_cmd *cmd, t_parse *p)
 {
-	cmd->fd_in = redirects_for_type(cmd, p, REDIR_IN);
-	cmd->fd_out = redirects_for_type(cmd, p, REDIR_OUT);
+	cmd->fd_in = redirects_for_type(p, REDIR_IN);
+	cmd->fd_out = redirects_for_type(p, REDIR_OUT);
 	return (cmd);
 }

--- a/sources/utils/control_utils.c
+++ b/sources/utils/control_utils.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/29 21:56:32 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/03/29 21:58:02 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/04/04 16:46:46 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 
 void ft_sleep(size_t count)
 {
-	int	i;
-	int j;
+	size_t	i;
+	size_t	j;
 
 	i = 0;
 	j = 0;

--- a/sources/utils/function_protection.c
+++ b/sources/utils/function_protection.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/29 13:21:05 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/03/22 16:06:01 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 20:54:20 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 void	*safe_malloc(size_t size)
 {
 	void	*ptr;
-	
+
 	ptr = malloc(size);
 	if (ptr == NULL)
 	{

--- a/sources/utils/shell_init.c
+++ b/sources/utils/shell_init.c
@@ -6,13 +6,13 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/14 14:04:02 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/03/28 15:01:17 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/04/04 20:57:35 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static int		count_substrings(char **strings)
+static int	count_substrings(char **strings)
 {
 	int	i;
 
@@ -34,7 +34,6 @@ static char	**alloc_envp(char **envp)
 		copy_envp[i] = ft_strdup(envp[i]); // TODO protect
 		i++;
 	}
-	copy_envp[i] = 0;
 	return (copy_envp);
 }
 
@@ -50,6 +49,7 @@ t_shell	*shell_init(char **envp, char **argv)
 {
 	t_shell	*shell;
 
+	(void)envp;
 	shell = safe_malloc(sizeof(t_shell));
 	shell->cmd_table = init_cmd_table();
 	shell->envp = alloc_envp(envp);

--- a/sources/utils/shell_init.c
+++ b/sources/utils/shell_init.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/14 14:04:02 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/04/04 20:57:35 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 21:00:28 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,6 @@ t_shell	*shell_init(char **envp, char **argv)
 {
 	t_shell	*shell;
 
-	(void)envp;
 	shell = safe_malloc(sizeof(t_shell));
 	shell->cmd_table = init_cmd_table();
 	shell->envp = alloc_envp(envp);

--- a/sources/utils/shell_init.c
+++ b/sources/utils/shell_init.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/14 14:04:02 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/04/04 21:00:28 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/04/04 22:40:42 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ static char	**alloc_envp(char **envp)
 		copy_envp[i] = ft_strdup(envp[i]); // TODO protect
 		i++;
 	}
+	copy_envp[i] = 0; // ? gives heap overflow??
 	return (copy_envp);
 }
 


### PR DESCRIPTION
- Issue #58 in progress.
- All Makefile flag options errors are resolved; except for the validation struct @ single_command function
- Fixed free split struct, index issue @ dup_infile
- Alloc_envp gives heap buffer overflow error. Genuinely don't understand why. Remove the null terminator and it stops complaining, but execve fails instead