### PR TITLE
Bugfix/#144 error codes

### DIFF
--- a/includes/error_messages.h
+++ b/includes/error_messages.h
@@ -6,12 +6,14 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/15 20:04:35 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 10:26:10 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/21 17:15:53 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef ERROR_MESSAGES_H
 # define ERROR_MESSAGES_H
+
+# include "minishell.h"
 
 // Show error message
 # define E_QUOTE				"unmatched quote."
@@ -44,10 +46,11 @@
 # define X_SIG_BACKSLASH		131
 # define X_CMD					127
 
+typedef struct s_shell	t_shell;
+
 // error_messages.c
-void	arg_error(void);
-void	numeric_error(char *str);
-int		show_error_message(char *error, char *color, char *arg, int exit_code);
-int		exit_with_message(char *error, char *color, int exit_code);
+int		show_error_message(char *error, t_shell *shell, char *arg, \
+							int exit_code);
+int		exit_with_message(char *error, t_shell *shell, int exit_code);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:15:00 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 15:01:22 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 18:32:34 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -171,6 +171,7 @@ typedef struct s_cmd_table
 
 typedef struct s_builtin \
 	t_builtin;
+
 typedef struct s_shell
 {
 	t_token				*tokens;
@@ -219,7 +220,7 @@ t_token			*assign_argfile_args(t_token *current);
 t_token			*assign_cmd_arg(t_token *current, int i);
 
 // lexer.c
-t_token			*token_constructor(char *split_input, int i);
+t_token			*token_constructor(char *split_input, int i, t_shell *shell);
 int				tokens_builder_manager(t_shell *shell);
 int				shell_lexer(t_shell *shell);
 
@@ -241,7 +242,7 @@ void			buffer_quote(t_split *sp, int quote_type);
 
 //===============================================================: Lexer / Split
 // allocate_strings.c
-char			**allocate_strings_split(t_split *sp);
+char			**allocate_strings_split(t_split *sp, t_shell *shell);
 
 // split_utils.c
 t_split			*init_split(t_shell *shell, t_split *split);
@@ -258,20 +259,20 @@ t_split			*split(t_shell *shell);
 bool			shell_parser(t_shell *shell);
 
 // parser_cmd_arguments.c
-t_cmd			*construct_args(t_cmd *cmd, t_parse *p);
+t_cmd			*construct_args(t_cmd *cmd, t_parse *p, t_shell *shell);
 
 // parser_post_process.c
 int				parser_post_process(t_shell *shell);
 
 // parser_checks.c
-bool			parser_checks(t_token *tokens);
+bool			parser_checks(t_shell *shell);
 
 // parser_redirects_utils.c
 t_redirect_type	assign_file_type(char *value);
 bool			should_add_files(t_token_type current_type, t_token_type type);
 
 // parser_redirects.c
-t_cmd			*construct_redirects(t_cmd *cmd, t_parse *p);
+t_cmd			*construct_redirects(t_cmd *cmd, t_parse *p, t_shell *shell);
 
 // parser_strip_quotes.c
 char			*new_strip_quotes(char *arg);
@@ -279,13 +280,13 @@ char			*strip_quote_for_type(char *arg);
 
 // parser_utils.c
 t_parse			*init_parse(t_shell *shell);
-t_cmd			*allocate_cmd(void);
+t_cmd			*allocate_cmd(t_shell *shell);
 t_token			*locate_current_token(t_parse *p);
 t_token			*locate_pipe_n(t_token *tokens_root, int pipe_count);
 
 //===============================================================: Executor
 // executor_enviroment.c
-char			**format_cmd(t_cmd *cmd);
+char			**format_cmd(t_cmd *cmd, t_shell *shell);
 char			*get_path_for_cmd(char **env_paths, char *command);
 char			*ft_getenv(t_shell *shell, char *input);
 char			**get_paths(t_shell *shell);
@@ -368,7 +369,8 @@ int				final_cmd(t_shell *shell, t_cmd *cmd, int pipe_in);
 t_validation	execute_piped_command(t_shell *shell, t_cmd *cmd);
 
 // execute_wait.c
-int				wait_for_last_cmd(int child_count, int last_pid);
+int				wait_for_last_cmd(int child_count, int last_pid, \
+					t_shell *shell);
 
 // ----------------------------------- executor/pipe
 // pipe_utils.c
@@ -376,18 +378,20 @@ int				count_pipes(t_shell *shell);
 
 // ----------------------------------- executor/redirects
 // redirect_heredoc
-int				setup_heredoc(t_redirect *heredoc, int *stat_loc);
+int				setup_heredoc(t_redirect *heredoc, int *stat_loc, \
+					t_shell *shell);
 
 // redirect_in_files.c
-t_validation	redirect_in_files(t_cmd *cmd, int *stat_loc);
+t_validation	redirect_in_files(t_cmd *cmd, int *stat_loc, t_shell *shell);
 
 // redirect_open.c
-int				safe_open(char *path, t_redirect_type oflag, int mode);
-t_in_files		*open_in_files(t_cmd *cmd, t_in_files *ins, \
+int				safe_open(char *path, t_redirect_type oflag, int mode, \
+					t_shell *shell);
+t_in_files		*open_in_files(t_shell *shell, t_in_files *ins, \
 					t_redirect_type type, int *stat_loc);
 
 // redirect_out_files.c
-t_validation	redirect_out(t_cmd *cmd);
+t_validation	redirect_out(t_cmd *cmd, t_shell *shell);
 
 // redirect_types.c
 t_redirect		*file_type(t_cmd *cmd, t_redirect_type type);
@@ -407,31 +411,33 @@ void			rl_replace_line(const char *text, int clear_undo);
 // expander_utils.c
 int				count_expand(char *arg);
 bool			is_arg_key(char *arg, char *key);
-char			*expand_exit_code(char *arg, char *key, size_t i);
+char			*expand_exit_code(char *arg, char *key, size_t i, \
+					t_shell *shell);
 
 // expander.c
-char			*will_expand(char **env, char *arg);
+char			*will_expand(char **env, char *arg, t_shell *shell);
 
 // get_env_key.c
-char			*skip_multiple_expand_chars(char *arg, size_t i);
-char			*get_env_key(char *arg, size_t i);
+char			*skip_multiple_expand_chars(char *arg, size_t i, \
+					t_shell *shell);
+char			*get_env_key(char *arg, size_t i, t_shell *shell);
 
 //===============================================================: Utils
 // control_utils.c
 void			ft_sleep(size_t count);
 
 // env_utils.c
-char			*get_value_for_key(char **env, char *key);
+char			*get_value_for_key(char **env, char *key, t_shell *shell);
 int				count_lines_from(char **env, int index);
 size_t			env_size(char **env);
 int				index_for_env_key(char **input_env, char *key);
 
 // function_protection.c
-void			*safe_strjoin(const char *s1, const char *s2);
-void			*safe_malloc(size_t size);
-void			*safe_calloc(size_t count, size_t size);
-char			*safe_strdup(char *str);
-char			*safe_strdup_from(const char *str, int i);
+void			*safe_strjoin(const char *s1, const char *s2, t_shell *shell);
+void			*safe_malloc(size_t size, t_shell *shell);
+void			*safe_calloc(size_t count, size_t size, t_shell *shell);
+char			*safe_strdup(char *str, t_shell *shell);
+char			*safe_strdup_from(const char *str, int i, t_shell *shell);
 
 // print_cmds.c
 void			print_cmds(t_cmd_table *cmd_table);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:15:00 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 18:32:34 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 17:50:39 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,6 @@
 
 # define READ 0
 # define WRITE 1
-
 # define C_YELLOW "\033[1;33m"
 # define C_RED "\x1B[1;31m"
 # define RESET_COLOR "\033[0m"
@@ -53,7 +52,7 @@
 # define PRINT_FLAG "-p"
 
 //===============================================================: Global
-extern int	g_exit_code;
+extern int	g_signal;
 
 //===============================================================: Enum
 typedef enum e_validation

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:15:00 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/23 17:50:39 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/23 22:22:51 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -202,6 +202,13 @@ typedef struct s_in_files
 	int		*infiles;
 }	t_in_files;
 
+typedef struct s_cmd_data
+{
+    t_cmd 		*cmd;
+    t_shell 	*shell;
+    t_in_files 	*ins;
+}	t_cmd_data;
+
 //===============================================================: Main
 // shell_init.c
 t_shell			*shell_pre_init(t_shell *shell, char **envp, char **argv);
@@ -386,8 +393,8 @@ t_validation	redirect_in_files(t_cmd *cmd, int *stat_loc, t_shell *shell);
 // redirect_open.c
 int				safe_open(char *path, t_redirect_type oflag, int mode, \
 					t_shell *shell);
-t_in_files		*open_in_files(t_shell *shell, t_in_files *ins, \
-					t_redirect_type type, int *stat_loc);
+t_in_files		*open_in_files(t_cmd_data *d, t_redirect_type type, \
+					int *stat_loc);
 
 // redirect_out_files.c
 t_validation	redirect_out(t_cmd *cmd, t_shell *shell);

--- a/sources/builtins/builtins.c
+++ b/sources/builtins/builtins.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   builtins.c                                         :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: qbeukelm <qbeukelm@student.42.fr>          +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/03/01 14:47:56 by qtrinh            #+#    #+#             */
-/*   Updated: 2024/06/07 14:00:05 by qbeukelm         ###   ########.fr       */
+/*                                                        ::::::::            */
+/*   builtins.c                                         :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2024/03/01 14:47:56 by qtrinh        #+#    #+#                 */
+/*   Updated: 2024/06/21 18:38:41 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ t_shell	*init_main_builtins(t_shell *shell)
 	builtin_table[B_EXPORT].function = export;
 	builtin_table[B_UNSET].name = "unset";
 	builtin_table[B_UNSET].function = unset;
-	shell->builtin_main = safe_malloc(B_NUM_MAIN * sizeof(t_builtin));
+	shell->builtin_main = safe_malloc(B_NUM_MAIN * sizeof(t_builtin), shell);
 	while (i < B_NUM_MAIN)
 	{
 		shell->builtin_main[i] = builtin_table[i];
@@ -47,7 +47,7 @@ t_shell	*init_child_builtins(t_shell *shell)
 	builtin_table[B_ENV].function = env;
 	builtin_table[B_PWD].name = "pwd";
 	builtin_table[B_PWD].function = pwd;
-	shell->builtin_child = safe_malloc(B_NUM_CHILD * sizeof(t_builtin));
+	shell->builtin_child = safe_malloc(B_NUM_CHILD * sizeof(t_builtin), shell);
 	while (i < B_NUM_CHILD)
 	{
 		shell->builtin_child[i] = builtin_table[i];
@@ -88,8 +88,8 @@ int	exec_builtin(t_builtin *table, t_cmd *cmd, t_shell *shell, int num)
 	{
 		if (ft_strncmp(cmd->value, table[i].name, ft_strlen(cmd->value)) == 0)
 		{
-			g_exit_code = table[i].function(cmd, shell);
-			return (g_exit_code);
+			shell->exit_code = table[i].function(cmd, shell);
+			return (shell->exit_code);
 		}
 		i++;
 	}

--- a/sources/builtins/cd.c
+++ b/sources/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 14:31:20 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/21 17:11:59 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/24 15:24:33 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,7 @@ int	cd(t_cmd *cmd, t_shell *shell)
 	char	*path;
 
 	if (cmd->arg_count > 1)
-		return (show_error_message(E_CD, shell, "", X_FAILURE));
+		return (show_error_message(E_CD, shell, "", X_FAILURE), 1);
 	if (minus_flag_check(cmd, shell) == false)
 		return (0);
 	path = determine_path(cmd, shell);
@@ -83,12 +83,12 @@ int	cd(t_cmd *cmd, t_shell *shell)
 	if (access(path, R_OK | X_OK) == -1)
 	{
 		free(path);
-		return (show_error_message(E_DENY, shell, cmd->args[0], X_FAILURE));
+		return (show_error_message(E_DENY, shell, cmd->args[0], 1), 1);
 	}
 	if (chdir(path) == -1)
 	{
 		free(path);
-		return (show_error_message(E_NO_FILE_DIR, shell, cmd->args[0], 1));
+		return (show_error_message(E_NO_FILE_DIR, shell, cmd->args[0], 1), 1);
 	}
 	else
 		update_env(shell);

--- a/sources/builtins/cd.c
+++ b/sources/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 14:31:20 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/14 14:56:04 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:11:59 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,10 +20,10 @@ static bool	minus_flag_check(t_cmd *cmd, t_shell *shell)
 		return (true);
 	else if (ft_strncmp(cmd->args[0], "-", 2) == 0)
 	{
-		path = get_value_for_key(shell->envp, "OLDPWD");
+		path = get_value_for_key(shell->envp, "OLDPWD", shell);
 		if (path == NULL)
 		{
-			show_error_message("OLDPWD not set: ", C_RED, cmd->value, 1);
+			show_error_message("OLDPWD not set: ", shell, cmd->value, 1);
 			return (free(path), false);
 		}
 		ft_putendl_fd(path, STDOUT_FILENO);
@@ -36,10 +36,10 @@ static char	*set_home_directory(t_cmd *cmd, t_shell *shell)
 {
 	char	*home_dir;
 
-	home_dir = get_value_for_key(shell->envp, "HOME");
+	home_dir = get_value_for_key(shell->envp, "HOME", shell);
 	if (home_dir == NULL)
 	{
-		show_error_message("HOME not set: ", C_RED, cmd->value, 1);
+		show_error_message("HOME not set: ", shell, cmd->value, 1);
 		return (NULL);
 	}
 	return (home_dir);
@@ -63,7 +63,7 @@ static char	*determine_path(t_cmd *cmd, t_shell *shell)
 		path = set_home_directory(cmd, shell);
 		return (path);
 	}
-	path = safe_strdup(cmd->args[0]);
+	path = safe_strdup(cmd->args[0], shell);
 	if (path == NULL)
 		return (NULL);
 	return (path);
@@ -74,7 +74,7 @@ int	cd(t_cmd *cmd, t_shell *shell)
 	char	*path;
 
 	if (cmd->arg_count > 1)
-		return (show_error_message(E_CD, C_RED, "", X_FAILURE));
+		return (show_error_message(E_CD, shell, "", X_FAILURE));
 	if (minus_flag_check(cmd, shell) == false)
 		return (0);
 	path = determine_path(cmd, shell);
@@ -83,12 +83,12 @@ int	cd(t_cmd *cmd, t_shell *shell)
 	if (access(path, R_OK | X_OK) == -1)
 	{
 		free(path);
-		return (show_error_message(E_DENY, C_RED, cmd->args[0], X_FAILURE));
+		return (show_error_message(E_DENY, shell, cmd->args[0], X_FAILURE));
 	}
 	if (chdir(path) == -1)
 	{
 		free(path);
-		return (show_error_message(E_NO_FILE_DIR, C_RED, cmd->args[0], 1));
+		return (show_error_message(E_NO_FILE_DIR, shell, cmd->args[0], 1));
 	}
 	else
 		update_env(shell);

--- a/sources/builtins/cd_utils.c
+++ b/sources/builtins/cd_utils.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/30 16:09:22 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/05/30 17:27:30 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:24:09 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ static void	update_pwd(t_shell *shell, char *buff)
 	if (j != -1)
 	{
 		free(shell->envp[j]);
-		shell->envp[j] = safe_strjoin("PWD=", buff);
+		shell->envp[j] = safe_strjoin("PWD=", buff, shell);
 	}
 }
 
@@ -30,13 +30,13 @@ static void	update_oldpwd(t_shell *shell)
 	char	*pwd;
 
 	i = index_for_env_key(shell->envp, "OLDPWD");
-	pwd = get_value_for_key(shell->envp, "PWD");
+	pwd = get_value_for_key(shell->envp, "PWD", shell);
 	if (pwd == NULL)
 		return (free(pwd));
 	if (i != -1)
 	{
 		free(shell->envp[i]);
-		shell->envp[i] = safe_strjoin("OLDPWD=", pwd);
+		shell->envp[i] = safe_strjoin("OLDPWD=", pwd, shell);
 		free(pwd);
 	}
 	else
@@ -50,10 +50,10 @@ void	update_env(t_shell *shell)
 	char	*buff;
 
 	buff = getcwd(NULL, 0);
-	oldpwd = get_value_for_key(shell->envp, "OLDPWD");
+	oldpwd = get_value_for_key(shell->envp, "OLDPWD", shell);
 	if (oldpwd != NULL)
 		update_oldpwd(shell);
-	pwd = get_value_for_key(shell->envp, "PWD");
+	pwd = get_value_for_key(shell->envp, "PWD", shell);
 	if (pwd != NULL)
 		update_pwd(shell, buff);
 	free(oldpwd);

--- a/sources/builtins/echo.c
+++ b/sources/builtins/echo.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/07 14:45:13 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/04/24 18:10:51 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/24 15:52:20 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,14 +48,14 @@ int	echo(t_cmd *cmd, t_shell *shell)
 
 	(void) shell;
 	flag = is_echo_flag(cmd);
-	if (flag && cmd->arg_count <= 1)
-		return (SUCCESS);
 	if (cmd->arg_count == 0)
 	{
 		ft_putchar_fd('\n', STDOUT_FILENO);
-		return (SUCCESS);
+		exit(EXIT_SUCCESS);
 	}
+	if (flag && cmd->arg_count <= 1)
+		exit(EXIT_SUCCESS);
 	if (cmd->arg_count > 0)
 		print_echo(cmd, flag);
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/sources/builtins/env.c
+++ b/sources/builtins/env.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/07 14:45:44 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/04/18 14:16:08 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/24 15:55:41 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,6 @@ int	env(t_cmd *cmd, t_shell *shell)
 {
 	int		i;
 
-	(void)shell;
 	(void)cmd;
 	i = 0;
 	if (shell->envp == NULL)
@@ -26,5 +25,5 @@ int	env(t_cmd *cmd, t_shell *shell)
 		ft_putendl_fd(shell->envp[i], STDOUT_FILENO);
 		i++;
 	}
-	exit(0);
+	exit(EXIT_SUCCESS);
 }

--- a/sources/builtins/exit.c
+++ b/sources/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/03 09:41:20 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:10:05 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/24 15:22:51 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ int	exit_shell(t_cmd *cmd, t_shell *shell)
 	if (shell->cmd_table->cmd_count == 1)
 		ft_putstr_fd("exit\n", STDOUT_FILENO);
 	if (cmd->arg_count > 1)
-		return (show_error_message(E_ARG_ERR, shell, "", X_FAILURE));
+		return (show_error_message(E_ARG_ERR, shell, "", X_FAILURE), 1);
 	if (cmd->arg_count == 1)
 	{
 		if (ft_isnumber(cmd->args[0]) == false || ft_strlen(cmd->args[0]) > 19)

--- a/sources/builtins/exit.c
+++ b/sources/builtins/exit.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/03 09:41:20 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/05/17 14:09:01 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:10:05 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,17 +30,16 @@ static bool	ft_isnumber(char *str)
 
 int	exit_shell(t_cmd *cmd, t_shell *shell)
 {
-	(void) shell;
 	if (shell->cmd_table->cmd_count == 1)
 		ft_putstr_fd("exit\n", STDOUT_FILENO);
 	if (cmd->arg_count > 1)
-		return (show_error_message(E_ARG_ERR, C_RED, "", X_FAILURE));
+		return (show_error_message(E_ARG_ERR, shell, "", X_FAILURE));
 	if (cmd->arg_count == 1)
 	{
 		if (ft_isnumber(cmd->args[0]) == false || ft_strlen(cmd->args[0]) > 19)
-			exit_with_message(E_NUMERIC_ERR, RESET_COLOR, X_NUMERIC_ERR);
+			exit_with_message(E_NUMERIC_ERR, shell, X_NUMERIC_ERR);
 		else
-			g_exit_code = ft_atoi(cmd->args[0]) % 256;
+			shell->exit_code = ft_atoi(cmd->args[0]) % 256;
 	}
-	exit(g_exit_code);
+	exit(shell->exit_code);
 }

--- a/sources/builtins/export.c
+++ b/sources/builtins/export.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/13 21:25:42 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/24 15:16:34 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,13 +81,13 @@ int	export(t_cmd *cmd, t_shell *shell)
 
 	i = 0;
 	if (cmd->args[i] == NULL)
-		return (show_error_message(E_EXPORT, shell, "", X_FAILURE));
+		return (show_error_message(E_EXPORT, shell, "", X_FAILURE), 1);
 	while (i < cmd->arg_count)
 	{
 		if (is_valid_export_arg(cmd->args[i]))
 			add_arg_to_env(shell, cmd->args[i]);
 		else
-			return (show_error_message(E_EXPORT, shell, cmd->args[i], 1));
+			return (show_error_message(E_EXPORT, shell, cmd->args[i], 1), 1);
 		i++;
 	}
 	return (0);

--- a/sources/builtins/export.c
+++ b/sources/builtins/export.c
@@ -6,19 +6,19 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/13 21:25:42 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/05/31 17:06:34 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static char	*env_key_from_arg(const char *arg)
+static char	*env_key_from_arg(t_shell *shell, const char *arg)
 {
 	int		i;
 	char	*key;
 
 	i = 0;
-	key = safe_malloc(sizeof(char *) * ft_strlen(arg));
+	key = safe_malloc(sizeof(char *) * ft_strlen(arg), shell);
 	while (arg[i])
 	{
 		if (arg[i] == '=')
@@ -43,17 +43,17 @@ static void	add_new_arg(t_shell *shell, char *arg)
 	new_env = ft_realloc(shell->envp, (count + 2) * sizeof(char *));
 	if (new_env == NULL)
 	{
-		show_error_message(E_MALLOC, C_RED, "", X_FAILURE);
+		show_error_message(E_MALLOC, shell, "", X_FAILURE);
 		return ;
 	}
 	while (shell->envp[i])
 	{
-		new_env[i] = safe_strdup(shell->envp[i]);
+		new_env[i] = safe_strdup(shell->envp[i], shell);
 		free(shell->envp[i]);
 		i++;
 	}
 	free(shell->envp);
-	new_env[count] = safe_strdup(arg);
+	new_env[count] = safe_strdup(arg, shell);
 	new_env[count + 1] = NULL;
 	shell->envp = new_env;
 }
@@ -63,12 +63,12 @@ static void	add_arg_to_env(t_shell *shell, char *arg)
 	int		insert_index;
 	char	*key;
 
-	key = env_key_from_arg(arg);
+	key = env_key_from_arg(shell, arg);
 	insert_index = index_for_env_key(shell->envp, key);
 	if (insert_index != -1)
 	{
 		free(shell->envp[insert_index]);
-		shell->envp[insert_index] = safe_strdup(arg);
+		shell->envp[insert_index] = safe_strdup(arg, shell);
 	}
 	else
 		add_new_arg(shell, arg);
@@ -81,13 +81,13 @@ int	export(t_cmd *cmd, t_shell *shell)
 
 	i = 0;
 	if (cmd->args[i] == NULL)
-		return (show_error_message(E_EXPORT, C_RED, "", X_FAILURE));
+		return (show_error_message(E_EXPORT, shell, "", X_FAILURE));
 	while (i < cmd->arg_count)
 	{
 		if (is_valid_export_arg(cmd->args[i]))
 			add_arg_to_env(shell, cmd->args[i]);
 		else
-			return (show_error_message(E_EXPORT, C_RED, cmd->args[i], 1));
+			return (show_error_message(E_EXPORT, shell, cmd->args[i], 1));
 		i++;
 	}
 	return (0);

--- a/sources/executor/execute_command/execute_command.c
+++ b/sources/executor/execute_command/execute_command.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/22 21:21:55 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 11:00:37 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,11 +22,11 @@ t_validation	execute_command(t_shell *shell, int i)
 	cmd_path = shell->cmd_table->cmds[i]->cmd_path;
 	cmd_and_args = shell->cmd_table->cmds[i]->cmd_and_args;
 	if (cmd_path == NULL)
-		exit(g_exit_code);
+		exit(shell->exit_code);
 	if (execve(cmd_path, cmd_and_args, shell->envp) == -1)
 	{
-		show_error_message(E_EXECVE, C_RED, cmd_value, X_FAILURE);
-		exit(g_exit_code);
+		show_error_message(E_EXECVE, shell, cmd_value, X_FAILURE);
+		exit(shell->exit_code);
 		return (FAILURE);
 	}
 	return (SUCCESS);

--- a/sources/executor/execute_command/single_command.c
+++ b/sources/executor/execute_command/single_command.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 14:28:14 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/21 18:36:27 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 18:13:44 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,6 +76,8 @@ int	single_command(t_shell *shell)
 	else if (pid > 0)
 	{
 		waitpid(pid, &st_loc, 0);
+		if (g_signal == SIGQUIT)
+			shell->exit_code = X_SIG_BACKSLASH;
 		if (WIFEXITED(st_loc))
 			return (WEXITSTATUS(st_loc));
 	}

--- a/sources/executor/execute_command/single_command.c
+++ b/sources/executor/execute_command/single_command.c
@@ -6,33 +6,33 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 14:28:14 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/13 10:53:05 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/21 18:36:27 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
 
-static t_validation	assign_out_redirects(t_cmd *cmd)
+static t_validation	assign_out_redirects(t_cmd *cmd, t_shell *shell)
 {
 	t_validation	validation;
 
 	validation = SUCCESS;
 	if (cmd->fd_out)
-		validation = redirect_out(cmd);
+		validation = redirect_out(cmd, shell);
 	return (validation);
 }
 
-void	should_exit_no_command(t_cmd *cmd)
+static void	should_exit_no_command(t_cmd *cmd, t_shell *shell)
 {
 	if (ft_strncmp(cmd->cmd_path, CMD_NOT_FOUND_STR, 1) == 0)
 	{
-		show_error_message(E_CMD_NOT_FOUND, C_RED, cmd->value, X_CMD);
-		exit(g_exit_code);
+		show_error_message(E_CMD_NOT_FOUND, shell, cmd->value, X_CMD);
+		exit(shell->exit_code);
 	}
 	else if (cmd->cmd_path == NULL)
 	{
-		g_exit_code = 0;
-		exit(g_exit_code);
+		shell->exit_code = 0;
+		exit(shell->exit_code);
 	}
 }
 
@@ -41,14 +41,14 @@ t_validation	child_process(t_shell *shell)
 	t_cmd	*cmd;
 
 	cmd = shell->cmd_table->cmds[0];
-	if (assign_out_redirects(cmd) == SUCCESS)
+	if (assign_out_redirects(cmd, shell) == SUCCESS)
 	{
 		if (is_builtin(shell->builtin_child, cmd, B_NUM_CHILD))
 			exec_builtin(shell->builtin_child, cmd, shell, B_NUM_CHILD);
 		else
 		{
 			prepare_command(shell, 0);
-			should_exit_no_command(cmd);
+			should_exit_no_command(cmd, shell);
 			return (execute_command(shell, 0));
 		}
 	}
@@ -58,26 +58,26 @@ t_validation	child_process(t_shell *shell)
 int	single_command(t_shell *shell)
 {
 	pid_t			pid;
-	int				stat_loc;
+	int				st_loc;
 
-	stat_loc = 0;
-	if (redirect_in_files(shell->cmd_table->cmds[0], &stat_loc) == SUCCESS)
-		g_exit_code = 0;
-	if (stat_loc >= 1)
-		stat_loc = 1;
-	if (WIFSIGNALED(stat_loc))
-		return (g_exit_code = X_SIG_HEREDOC);
+	st_loc = 0;
+	if (redirect_in_files(shell->cmd_table->cmds[0], &st_loc, shell) == SUCCESS)
+		shell->exit_code = 0;
+	if (st_loc >= 1)
+		st_loc = 1;
+	if (WIFSIGNALED(st_loc))
+		return (shell->exit_code = X_SIG_HEREDOC);
 	handle_signals(CHILD);
 	pid = fork();
 	if (pid < 0)
-		exit_with_message(E_FORK, C_RED, X_FAILURE);
+		exit_with_message(E_FORK, shell, X_FAILURE);
 	if (pid == 0)
 		child_process(shell);
 	else if (pid > 0)
 	{
-		waitpid(pid, &stat_loc, 0);
-		if (WIFEXITED(stat_loc))
-			return (WEXITSTATUS(stat_loc));
+		waitpid(pid, &st_loc, 0);
+		if (WIFEXITED(st_loc))
+			return (WEXITSTATUS(st_loc));
 	}
-	return (g_exit_code);
+	return (shell->exit_code);
 }

--- a/sources/executor/execute_commands/execute_commands.c
+++ b/sources/executor/execute_commands/execute_commands.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/22 21:09:40 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 15:44:19 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:29:18 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ static int	pipe_commands(t_shell *sh, t_cmd *cmd, t_childs *ch, bool last_cmd)
 	if (last_cmd == false)
 	{
 		if (pipe(ch->pipe_fd[flip]) < 0)
-			exit_with_message(E_PIPE_FAIL, C_RED, X_FAILURE);
+			exit_with_message(E_PIPE_FAIL, sh, X_FAILURE);
 	}
 	if (ch->child_count == 0)
 		first_cmd(sh, cmd, ch->pipe_fd[flip]);
@@ -50,13 +50,13 @@ static int	execute_cmd_for(t_shell *shell, int i, t_childs *ch)
 	last_cmd = is_last_cmd(shell->cmd_table->cmd_count, i);
 	cmd = shell->cmd_table->cmds[i];
 	if (cmd->fd_in)
-		if (redirect_in_files(cmd, &stat_loc) == SUCCESS)
-			g_exit_code = 0;
+		if (redirect_in_files(cmd, &stat_loc, shell) == SUCCESS)
+			shell->exit_code = 0;
 	if (stat_loc >= 1)
 		stat_loc = 1;
 	if (WIFSIGNALED(stat_loc))
 	{
-		g_exit_code = X_SIG_HEREDOC;
+		shell->exit_code = X_SIG_HEREDOC;
 		return (-1);
 	}
 	prepare_command(shell, i);
@@ -77,10 +77,10 @@ int	execute_commands(t_shell *shell)
 	{
 		last_pid = execute_cmd_for(shell, i, &ch);
 		if (last_pid < 0)
-			return (g_exit_code);
+			return (shell->exit_code);
 		ch.child_count++;
 		i++;
 	}
-	return_value = wait_for_last_cmd(ch.child_count, last_pid);
+	return_value = wait_for_last_cmd(ch.child_count, last_pid, shell);
 	return (return_value);
 }

--- a/sources/executor/execute_commands/execute_pipe.c
+++ b/sources/executor/execute_commands/execute_pipe.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/22 21:17:02 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 15:42:20 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 18:29:57 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 static void	manage_execution(t_shell *shell, t_cmd *cmd)
 {
 	if (cmd->fd_out)
-		redirect_out(cmd);
+		redirect_out(cmd, shell);
 	if (is_builtin(shell->builtin_main, cmd, B_NUM_MAIN))
 		exec_builtin(shell->builtin_main, cmd, shell, B_NUM_MAIN);
 	else
@@ -29,23 +29,23 @@ void	first_cmd(t_shell *shell, t_cmd *cmd, int pipe_out[2])
 	signal(SIGINT, SIG_IGN);
 	fork_id = fork();
 	if (fork_id < 0)
-		exit_with_message(E_FORK, C_RED, X_FAILURE);
+		exit_with_message(E_FORK, shell, X_FAILURE);
 	handle_signals(CHILD);
 	if (fork_id == 0)
 	{
 		if (dup2(pipe_out[WRITE], STDOUT_FILENO) < 0)
 		{
-			show_error_message(E_DUP, C_RED, cmd->value, X_FAILURE);
+			show_error_message(E_DUP, shell, cmd->value, X_FAILURE);
 			if (close_fds(pipe_out[WRITE], pipe_out[READ], -1) == false)
-				exit_with_message(E_CLOSE, C_RED, X_FAILURE);
-			exit(g_exit_code);
+				exit_with_message(E_CLOSE, shell, X_FAILURE);
+			exit(shell->exit_code);
 		}
 		if (close_fds(pipe_out[WRITE], pipe_out[READ], -1) == false)
-			exit_with_message(E_CLOSE, C_RED, X_FAILURE);
+			exit_with_message(E_CLOSE, shell, X_FAILURE);
 		manage_execution(shell, cmd);
 	}
 	if (close_fds(pipe_out[WRITE], -1, -1) == false)
-		show_error_message(E_CLOSE, C_RED, "parent first cmd", X_FAILURE);
+		show_error_message(E_CLOSE, shell, "parent first cmd", X_FAILURE);
 }
 
 void	mid_cmd(t_shell *shell, t_cmd *cmd, int pipe_in, int pipe_out[2])
@@ -55,24 +55,24 @@ void	mid_cmd(t_shell *shell, t_cmd *cmd, int pipe_in, int pipe_out[2])
 	signal(SIGINT, SIG_IGN);
 	fork_id = fork();
 	if (fork_id < 0)
-		exit_with_message(E_FORK, C_RED, X_FAILURE);
+		exit_with_message(E_FORK, shell, X_FAILURE);
 	handle_signals(CHILD);
 	if (fork_id == 0)
 	{
 		if (dup2(pipe_out[WRITE], STDOUT_FILENO) < 0 || \
 			dup2(pipe_in, STDIN_FILENO) < 0)
 		{
-			show_error_message(E_DUP, C_RED, cmd->value, X_FAILURE);
+			show_error_message(E_DUP, shell, cmd->value, X_FAILURE);
 			if (close_fds(pipe_out[WRITE], pipe_in, -1) == false)
-				exit_with_message(E_CLOSE, C_RED, X_FAILURE);
-			exit(g_exit_code);
+				exit_with_message(E_CLOSE, shell, X_FAILURE);
+			exit(shell->exit_code);
 		}
 		if (close_fds(pipe_in, pipe_out[WRITE], pipe_out[READ]) == false)
-			exit_with_message(E_CLOSE, C_RED, X_FAILURE);
+			exit_with_message(E_CLOSE, shell, X_FAILURE);
 		manage_execution(shell, cmd);
 	}
 	if (close_fds(pipe_in, pipe_out[WRITE], -1) == false)
-		show_error_message(E_CLOSE, C_RED, "parent mid cmd", X_FAILURE);
+		show_error_message(E_CLOSE, shell, "parent mid cmd", X_FAILURE);
 }
 
 int	final_cmd(t_shell *shell, t_cmd *cmd, int pipe_in)
@@ -82,22 +82,22 @@ int	final_cmd(t_shell *shell, t_cmd *cmd, int pipe_in)
 	signal(SIGINT, SIG_IGN);
 	fork_id = fork();
 	if (fork_id < 0)
-		exit_with_message(E_FORK, C_RED, X_FAILURE);
+		exit_with_message(E_FORK, shell, X_FAILURE);
 	handle_signals(CHILD);
 	if (fork_id == 0)
 	{
 		if (dup2(pipe_in, STDIN_FILENO) < 0)
 		{
-			show_error_message(E_DUP, C_RED, cmd->value, X_FAILURE);
+			show_error_message(E_DUP, shell, cmd->value, X_FAILURE);
 			if (close_fds(pipe_in, -1, -1) == false)
-				exit_with_message(E_CLOSE, C_RED, X_FAILURE);
-			exit(g_exit_code);
+				exit_with_message(E_CLOSE, shell, X_FAILURE);
+			exit(shell->exit_code);
 		}
 		if (close_fds(pipe_in, -1, -1) == false)
-			exit_with_message(E_CLOSE, C_RED, X_FAILURE);
+			exit_with_message(E_CLOSE, shell, X_FAILURE);
 		manage_execution(shell, cmd);
 	}
 	if (close_fds(pipe_in, -1, -1) == false)
-		show_error_message(E_CLOSE, C_RED, "parent last cmd", X_FAILURE);
+		show_error_message(E_CLOSE, shell, "parent last cmd", X_FAILURE);
 	return (fork_id);
 }

--- a/sources/executor/execute_commands/execute_piped_command.c
+++ b/sources/executor/execute_commands/execute_piped_command.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/22 21:13:57 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 15:44:33 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,11 +24,11 @@ t_validation	execute_piped_command(t_shell *shell, t_cmd *cmd)
 	if (is_builtin(shell->builtin_child, cmd, B_NUM_CHILD))
 		exec_builtin(shell->builtin_child, cmd, shell, B_NUM_CHILD);
 	if (cmd_path == NULL)
-		exit(g_exit_code);
+		exit(shell->exit_code);
 	else if (execve(cmd_path, cmd_and_args, shell->envp) == -1)
 	{
-		show_error_message(E_EXECVE, C_RED, cmd_value, X_FAILURE);
-		exit(g_exit_code);
+		show_error_message(E_EXECVE, shell, cmd_value, X_FAILURE);
+		exit(shell->exit_code);
 	}
 	return (SUCCESS);
 }

--- a/sources/executor/execute_commands/execute_wait.c
+++ b/sources/executor/execute_commands/execute_wait.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/22 21:17:34 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 16:01:14 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 18:19:08 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/sources/executor/execute_commands/execute_wait.c
+++ b/sources/executor/execute_commands/execute_wait.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/22 21:17:34 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/14 16:25:41 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 16:01:14 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 	WIFSIGNALED:	check if child process terminated through a signal.
 	WIFEXITED:		check if child process terminated normally.
 */
-int	wait_for_last_cmd(int child_count, int last_pid)
+int	wait_for_last_cmd(int child_count, int last_pid, t_shell *shell)
 {
 	int	i;
 	int	status;
@@ -38,8 +38,8 @@ int	wait_for_last_cmd(int child_count, int last_pid)
 		return (WEXITSTATUS(last_status));
 	else if (WIFSIGNALED(last_status))
 	{
-		g_exit_code = WTERMSIG(last_status) + 128;
-		return (g_exit_code);
+		shell->exit_code = WTERMSIG(last_status) + 128;
+		return (shell->exit_code);
 	}
 	return (-1);
 }

--- a/sources/executor/executor.c
+++ b/sources/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 19:16:50 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/05/26 13:32:46 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/21 18:24:49 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,11 +21,12 @@ int	shell_execute(t_shell *shell)
 	{
 		cmd = shell->cmd_table->cmds[0];
 		if (is_builtin(shell->builtin_main, cmd, B_NUM_MAIN))
-			exec_builtin(shell->builtin_main, cmd, shell, B_NUM_MAIN);
+			shell->exit_code = \
+				exec_builtin(shell->builtin_main, cmd, shell, B_NUM_MAIN);
 		else
-			g_exit_code = single_command(shell);
+			shell->exit_code = single_command(shell);
 	}
 	else
-		g_exit_code = execute_commands(shell);
-	return (g_exit_code);
+		shell->exit_code = execute_commands(shell);
+	return (shell->exit_code);
 }

--- a/sources/executor/executor_environment.c
+++ b/sources/executor/executor_environment.c
@@ -6,23 +6,23 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 19:45:47 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 15:20:38 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:23:40 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-char	**format_cmd(t_cmd *cmd)
+char	**format_cmd(t_cmd *cmd, t_shell *s)
 {
 	int			i;
 	char		**cmd_and_args;
 
 	i = 0;
-	cmd_and_args = safe_malloc(sizeof(char *) * (cmd->arg_count + 2));
-	cmd_and_args[0] = safe_strdup(cmd->value);
+	cmd_and_args = safe_malloc(sizeof(char *) * (cmd->arg_count + 2), s);
+	cmd_and_args[0] = safe_strdup(cmd->value, s);
 	while (i < cmd->arg_count)
 	{
-		cmd_and_args[i + 1] = safe_strdup(cmd->args[i]);
+		cmd_and_args[i + 1] = safe_strdup(cmd->args[i], s);
 		i++;
 	}
 	cmd_and_args[i + 1] = 0;
@@ -39,6 +39,8 @@ static char	*get_path_error_string(void)
 	char	*str;
 
 	str = malloc(2);
+	if (str == NULL)
+		return (NULL);
 	str[0] = '?';
 	str[1] = '\0';
 	return (str);
@@ -81,7 +83,7 @@ char	**get_paths(t_shell *shell)
 
 	env_paths = NULL;
 	env_path = NULL;
-	env_path = get_value_for_key(shell->envp, "PATH");
+	env_path = get_value_for_key(shell->envp, "PATH", shell);
 	if (env_path == NULL)
 		return (NULL);
 	env_paths = ft_split(env_path, ':');

--- a/sources/executor/executor_utils.c
+++ b/sources/executor/executor_utils.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 19:43:07 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 15:21:04 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 16:34:14 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,12 +23,12 @@ bool	close_fds(int fd1, int fd2, int fd3)
 	return (SUCCESS);
 }
 
-static bool	absolute_check(t_cmd *cmd)
+static bool	absolute_check(t_cmd *cmd, t_shell *shell)
 {
 	if (access(cmd->value, X_OK | F_OK) == 0)
 	{
-		cmd->cmd_path = safe_strdup(cmd->value);
-		cmd->cmd_and_args = format_cmd(cmd);
+		cmd->cmd_path = safe_strdup(cmd->value, shell);
+		cmd->cmd_and_args = format_cmd(cmd, shell);
 		return (SUCCESS);
 	}
 	return (FAILURE);
@@ -42,7 +42,7 @@ int	prepare_command(t_shell *shell, int i)
 
 	cmd_path = NULL;
 	cmd = shell->cmd_table->cmds[i];
-	if (absolute_check(cmd) == SUCCESS)
+	if (absolute_check(cmd, shell) == SUCCESS)
 		return (SUCCESS);
 	env_paths = get_paths(shell);
 	if (env_paths == NULL)
@@ -50,7 +50,7 @@ int	prepare_command(t_shell *shell, int i)
 		cmd->cmd_path = NULL;
 		return (FAILURE);
 	}
-	cmd->cmd_and_args = format_cmd(cmd);
+	cmd->cmd_and_args = format_cmd(cmd, shell);
 	cmd_path = get_path_for_cmd(env_paths, cmd->value);
 	free_2d_array(env_paths);
 	if (cmd_path == NULL)
@@ -58,7 +58,7 @@ int	prepare_command(t_shell *shell, int i)
 		cmd->cmd_path = cmd_path;
 		return (FAILURE);
 	}
-	cmd->cmd_path = safe_strdup(cmd_path);
+	cmd->cmd_path = safe_strdup(cmd_path, shell);
 	free (cmd_path);
 	return (SUCCESS);
 }

--- a/sources/executor/executor_utils.c
+++ b/sources/executor/executor_utils.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 19:43:07 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 16:34:14 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 21:26:25 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,6 +59,6 @@ int	prepare_command(t_shell *shell, int i)
 		return (FAILURE);
 	}
 	cmd->cmd_path = safe_strdup(cmd_path, shell);
-	free (cmd_path);
+	free(cmd_path);
 	return (SUCCESS);
 }

--- a/sources/executor/redirects/redirect_heredoc.c
+++ b/sources/executor/redirects/redirect_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/25 11:15:17 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/01 14:14:14 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 18:30:02 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ static bool	is_eof(char *line, char *eof)
 	return (false);
 }
 
-static int	perform_heredoc(int fd, t_redirect *heredoc)
+static int	perform_heredoc(int fd, t_redirect *heredoc, t_shell *shell)
 {
 	char	*line;
 
@@ -34,7 +34,7 @@ static int	perform_heredoc(int fd, t_redirect *heredoc)
 		if (line == NULL)
 		{
 			free(line);
-			exit_with_message(E_EOF_DESCRIPTOR, C_RED, g_exit_code);
+			exit_with_message(E_EOF_DESCRIPTOR, shell, shell->exit_code);
 		}
 		if (is_eof(line, heredoc->value) == true)
 		{
@@ -49,7 +49,7 @@ static int	perform_heredoc(int fd, t_redirect *heredoc)
 	return (0);
 }
 
-int	setup_heredoc(t_redirect *heredoc, int *stat_loc)
+int	setup_heredoc(t_redirect *heredoc, int *stat_loc, t_shell *shell)
 {
 	int		fd[2];
 	pid_t	pid;
@@ -57,21 +57,21 @@ int	setup_heredoc(t_redirect *heredoc, int *stat_loc)
 
 	stat_loc_local = 0;
 	if (pipe(fd) < 0)
-		exit_with_message(E_PIPE_FAIL, C_RED, X_FAILURE);
+		exit_with_message(E_PIPE_FAIL, shell, X_FAILURE);
 	signal(SIGINT, SIG_IGN);
 	pid = fork();
 	if (pid < 0)
-		exit_with_message(E_FORK, C_RED, X_FAILURE);
+		exit_with_message(E_FORK, shell, X_FAILURE);
 	if (pid == 0)
 	{
 		handle_signals(HEREDOC);
-		if (perform_heredoc(fd[WRITE], heredoc))
+		if (perform_heredoc(fd[WRITE], heredoc, shell))
 			exit(0);
 	}
 	else if (pid > 0)
 	{
 		if (close_fds(fd[WRITE], -1, -1) == false)
-			exit_with_message(E_CLOSE, C_RED, X_FAILURE);
+			exit_with_message(E_CLOSE, shell, X_FAILURE);
 		waitpid(pid, &stat_loc_local, 0);
 		*stat_loc = stat_loc_local;
 	}

--- a/sources/executor/redirects/redirect_in_files.c
+++ b/sources/executor/redirects/redirect_in_files.c
@@ -6,18 +6,16 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/24 22:08:44 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:33:31 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 22:22:59 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
 
-static t_in_files	*init_infiles(t_shell *s)
+static t_in_files	*init_infiles(t_cmd *cmd, t_shell *s)
 {
 	t_in_files	*ins;
-	t_cmd		*cmd;
 
-	cmd = s->cmd_table->cmds[0];
 	ins = safe_malloc(sizeof(t_in_files), s);
 	ins->heredocs = safe_malloc(sizeof(int *) * count_files(cmd, IN_APPEND), s);
 	ins->infiles = safe_malloc(sizeof(int *) * count_files(cmd, IN), s);
@@ -88,18 +86,22 @@ static void	dup_infile(t_cmd *cmd, t_in_files *ins, t_redirect_type type, \
 t_validation	redirect_in_files(t_cmd *cmd, int *stat_loc, t_shell *shell)
 {
 	t_redirect_type		last_type;
-	t_in_files			*ins;
+	t_in_files			*in_files;
+	t_cmd_data			data;
 
-	ins = init_infiles(shell);
+	data.cmd = cmd;
+	data.shell = shell;
+	in_files = init_infiles(cmd, shell);
+	data.ins = in_files;
 	last_type = last_infile_type(cmd);
-	ins = open_in_files(shell, ins, IN_APPEND, stat_loc);
-	ins = open_in_files(shell, ins, IN, NULL);
+	in_files = open_in_files(&data, IN_APPEND, stat_loc);
+	in_files = open_in_files(&data, IN, NULL);
 	if (last_type == IN_APPEND)
-		dup_infile(cmd, ins, IN_APPEND, shell);
+		dup_infile(cmd, in_files, IN_APPEND, shell);
 	else if (last_type == IN)
-		dup_infile(cmd, ins, IN, shell);
-	close_in_files(cmd, ins, IN_APPEND, shell);
-	close_in_files(cmd, ins, IN, shell);
-	free_ins(ins);
+		dup_infile(cmd, in_files, IN, shell);
+	close_in_files(cmd, in_files, IN_APPEND, shell);
+	close_in_files(cmd, in_files, IN, shell);
+	free_ins(in_files);
 	return (SUCCESS);
 }

--- a/sources/executor/redirects/redirect_in_files.c
+++ b/sources/executor/redirects/redirect_in_files.c
@@ -6,23 +6,26 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/24 22:08:44 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/14 16:14:24 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:33:31 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
 
-t_in_files	*init_infiles(t_cmd *cmd)
+static t_in_files	*init_infiles(t_shell *s)
 {
 	t_in_files	*ins;
+	t_cmd		*cmd;
 
-	ins = safe_malloc(sizeof(t_in_files));
-	ins->heredocs = safe_malloc(sizeof(int *) * count_files(cmd, IN_APPEND));
-	ins->infiles = safe_malloc(sizeof(int *) * count_files(cmd, IN));
+	cmd = s->cmd_table->cmds[0];
+	ins = safe_malloc(sizeof(t_in_files), s);
+	ins->heredocs = safe_malloc(sizeof(int *) * count_files(cmd, IN_APPEND), s);
+	ins->infiles = safe_malloc(sizeof(int *) * count_files(cmd, IN), s);
 	return (ins);
 }
 
-static void	close_in_files(t_cmd *cmd, t_in_files *fds, t_redirect_type type)
+static void	close_in_files(t_cmd *cmd, t_in_files *fds, t_redirect_type type, \
+							t_shell *shell)
 {
 	int		count;
 
@@ -32,18 +35,18 @@ static void	close_in_files(t_cmd *cmd, t_in_files *fds, t_redirect_type type)
 		if (type == IN_APPEND)
 		{
 			if (close_fds(fds->heredocs[count - 1], -1, -1) == false)
-				show_error_message(E_CLOSE, C_RED, ": IN_APPEND", X_FAILURE);
+				show_error_message(E_CLOSE, shell, ": IN_APPEND", X_FAILURE);
 		}
 		if (type == IN)
 		{
 			if (close_fds(fds->infiles[count - 1], -1, -1) == false)
-				show_error_message(E_CLOSE, C_RED, ": IN", X_FAILURE);
+				show_error_message(E_CLOSE, shell, ": IN", X_FAILURE);
 		}
 		count--;
 	}
 }
 
-static void	dup_for_fd(int fd)
+static void	dup_for_fd(int fd, t_shell *shell)
 {
 	int	dev_null_fd;
 
@@ -54,20 +57,21 @@ static void	dup_for_fd(int fd)
 		{
 			if (dup2(dev_null_fd, STDIN_FILENO) < 0)
 			{
-				show_error_message(E_DUP, C_RED, "dup2 dev_null_fd", X_FAILURE);
+				show_error_message(E_DUP, shell, "dup2 dev_null_fd", X_FAILURE);
 				if (close_fds(dev_null_fd, -1, -1) == false)
-					show_error_message(E_CLOSE, C_RED, "dup for fd", X_FAILURE);
+					show_error_message(E_CLOSE, shell, "dup for fd", X_FAILURE);
 			}
 			if (close_fds(dev_null_fd, -1, -1) == false)
-				show_error_message(E_CLOSE, C_RED, "dup for fd", X_FAILURE);
+				show_error_message(E_CLOSE, shell, "dup for fd", X_FAILURE);
 		}
 	}
 	else
 		if (dup2(fd, STDIN_FILENO) < 0)
-			show_error_message(E_DUP, C_RED, "", X_FAILURE);
+			show_error_message(E_DUP, shell, "", X_FAILURE);
 }
 
-static void	dup_infile(t_cmd *cmd, t_in_files *ins, t_redirect_type type)
+static void	dup_infile(t_cmd *cmd, t_in_files *ins, t_redirect_type type, \
+						t_shell *shell)
 {
 	int	index;
 
@@ -75,27 +79,27 @@ static void	dup_infile(t_cmd *cmd, t_in_files *ins, t_redirect_type type)
 	if (index >= 0)
 	{
 		if (type == IN_APPEND)
-			dup_for_fd(ins->heredocs[index]);
+			dup_for_fd(ins->heredocs[index], shell);
 		else if (type == IN)
-			dup_for_fd(ins->infiles[index]);
+			dup_for_fd(ins->infiles[index], shell);
 	}
 }
 
-t_validation	redirect_in_files(t_cmd *cmd, int *stat_loc)
+t_validation	redirect_in_files(t_cmd *cmd, int *stat_loc, t_shell *shell)
 {
 	t_redirect_type		last_type;
 	t_in_files			*ins;
 
-	ins = init_infiles(cmd);
+	ins = init_infiles(shell);
 	last_type = last_infile_type(cmd);
-	ins = open_in_files(cmd, ins, IN_APPEND, stat_loc);
-	ins = open_in_files(cmd, ins, IN, NULL);
+	ins = open_in_files(shell, ins, IN_APPEND, stat_loc);
+	ins = open_in_files(shell, ins, IN, NULL);
 	if (last_type == IN_APPEND)
-		dup_infile(cmd, ins, IN_APPEND);
+		dup_infile(cmd, ins, IN_APPEND, shell);
 	else if (last_type == IN)
-		dup_infile(cmd, ins, IN);
-	close_in_files(cmd, ins, IN_APPEND);
-	close_in_files(cmd, ins, IN);
+		dup_infile(cmd, ins, IN, shell);
+	close_in_files(cmd, ins, IN_APPEND, shell);
+	close_in_files(cmd, ins, IN, shell);
 	free_ins(ins);
 	return (SUCCESS);
 }

--- a/sources/executor/redirects/redirect_open.c
+++ b/sources/executor/redirects/redirect_open.c
@@ -6,13 +6,13 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/23 15:04:57 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/14 14:57:25 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
 
-int	safe_open(char *path, t_redirect_type oflag, int mode)
+int	safe_open(char *path, t_redirect_type oflag, int mode, t_shell *shell)
 {
 	int		fd;
 
@@ -22,32 +22,32 @@ int	safe_open(char *path, t_redirect_type oflag, int mode)
 	fd = open(path, oflag, mode);
 	if (access(path, R_OK) == -1)
 	{
-		show_error_message(E_DENY, C_RED, path, X_FAILURE);
-		exit(g_exit_code);
+		show_error_message(E_DENY, shell, path, X_FAILURE);
+		exit(shell->exit_code);
 	}
 	else if (fd == -1)
-		show_error_message(E_OPENING_FILE, C_RED, path, X_FAILURE);
+		show_error_message(E_OPENING_FILE, shell, path, X_FAILURE);
 	return (fd);
 }
 
-t_in_files	*open_in_files(t_cmd *cmd, t_in_files *ins, t_redirect_type type, \
-	int *stat_loc)
+t_in_files	*open_in_files(t_shell *shell, t_in_files *ins, \
+			t_redirect_type type, int *stat_loc)
 {
 	int			i;
 	t_redirect	*in;
 
 	i = 0;
-	in = cmd->fd_in;
+	in = shell->cmd_table->cmds[0]->fd_in;
 	while (in)
 	{
 		if (in->type == type && type == IN_APPEND)
 		{
-			ins->heredocs[i] = setup_heredoc(in, stat_loc);
+			ins->heredocs[i] = setup_heredoc(in, stat_loc, shell);
 			i++;
 		}
 		if (in->type == type && type == IN)
 		{
-			ins->infiles[i] = safe_open(in->value, get_open_flag(IN), 0);
+			ins->infiles[i] = safe_open(in->value, get_open_flag(IN), 0, shell);
 			i++;
 		}
 		if (in->next == NULL)

--- a/sources/executor/redirects/redirect_open.c
+++ b/sources/executor/redirects/redirect_open.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/23 15:04:57 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 22:23:03 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,29 +30,30 @@ int	safe_open(char *path, t_redirect_type oflag, int mode, t_shell *shell)
 	return (fd);
 }
 
-t_in_files	*open_in_files(t_shell *shell, t_in_files *ins, \
-			t_redirect_type type, int *stat_loc)
+t_in_files	*open_in_files(t_cmd_data *d, t_redirect_type type, \
+			int *stat_loc)
 {
 	int			i;
 	t_redirect	*in;
 
 	i = 0;
-	in = shell->cmd_table->cmds[0]->fd_in;
+	in = d->cmd->fd_in;
 	while (in)
 	{
 		if (in->type == type && type == IN_APPEND)
 		{
-			ins->heredocs[i] = setup_heredoc(in, stat_loc, shell);
+			d->ins->heredocs[i] = setup_heredoc(in, stat_loc, d->shell);
 			i++;
 		}
 		if (in->type == type && type == IN)
 		{
-			ins->infiles[i] = safe_open(in->value, get_open_flag(IN), 0, shell);
+			d->ins->infiles[i] = safe_open(in->value, get_open_flag(IN), \
+								0, d->shell);
 			i++;
 		}
 		if (in->next == NULL)
 			break ;
 		in = in->next;
 	}
-	return (ins);
+	return (d->ins);
 }

--- a/sources/executor/redirects/redirect_out_files.c
+++ b/sources/executor/redirects/redirect_out_files.c
@@ -1,18 +1,18 @@
 /* ************************************************************************** */
 /*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   redirect_out_files.c                               :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: qbeukelm <qbeukelm@student.42.fr>          +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2024/03/28 12:35:51 by quentinbeuk       #+#    #+#             */
-/*   Updated: 2024/06/14 14:35:11 by qbeukelm         ###   ########.fr       */
+/*                                                        ::::::::            */
+/*   redirect_out_files.c                               :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2024/03/28 12:35:51 by quentinbeuk   #+#    #+#                 */
+/*   Updated: 2024/06/21 17:34:08 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
 
-static t_validation	close_out_files(t_cmd *cmd)
+static t_validation	close_out_files(t_cmd *cmd, t_shell *shell)
 {
 	t_validation	validation;
 	t_redirect		*fd_curr;
@@ -24,7 +24,7 @@ static t_validation	close_out_files(t_cmd *cmd)
 		if (fd_curr->fd == -1)
 			validation = FAILURE;
 		if (close_fds(fd_curr->fd, -1, -1) == false)
-			show_error_message(E_CLOSE, C_RED, "fd_out", X_FAILURE);
+			show_error_message(E_CLOSE, shell, "fd_out", X_FAILURE);
 		fd_curr = fd_curr->next;
 	}
 	return (validation);
@@ -33,7 +33,7 @@ static t_validation	close_out_files(t_cmd *cmd)
 /*
 	Returnes fd of the last opened file
 */
-static int	open_out_files(t_cmd *cmd)
+static int	open_out_files(t_cmd *cmd, t_shell *s)
 {
 	t_redirect	*fd_lst_head;
 	t_redirect	*fd_lst_last;
@@ -43,7 +43,7 @@ static int	open_out_files(t_cmd *cmd)
 	curr = cmd->fd_out;
 	while (curr)
 	{
-		curr->fd = safe_open(curr->value, get_open_flag(curr->type), 0644);
+		curr->fd = safe_open(curr->value, get_open_flag(curr->type), 0644, s);
 		if (curr->fd == -1)
 			break ;
 		if (curr->next == NULL)
@@ -55,16 +55,16 @@ static int	open_out_files(t_cmd *cmd)
 	return (fd_lst_last->fd);
 }
 
-t_validation	redirect_out(t_cmd *cmd)
+t_validation	redirect_out(t_cmd *cmd, t_shell *shell)
 {
 	int		fd;
 	int		dev_null_fd;
 
-	fd = open_out_files(cmd);
+	fd = open_out_files(cmd, shell);
 	if (fd > 0)
 	{
 		if (dup2(fd, STDOUT_FILENO) < 0)
-			show_error_message(E_DUP, C_RED, "", X_FAILURE);
+			show_error_message(E_DUP, shell, "", X_FAILURE);
 	}
 	else
 	{
@@ -72,9 +72,9 @@ t_validation	redirect_out(t_cmd *cmd)
 		if (dev_null_fd >= 0)
 		{
 			if (dup2(dev_null_fd, STDOUT_FILENO) < 0)
-				show_error_message(E_DUP, C_RED, "", X_FAILURE);
+				show_error_message(E_DUP, shell, "", X_FAILURE);
 			cmd->fd_out->fd = dev_null_fd;
 		}
 	}
-	return (close_out_files(cmd));
+	return (close_out_files(cmd, shell));
 }

--- a/sources/executor/signals/signals.c
+++ b/sources/executor/signals/signals.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/02 14:17:42 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:37:58 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 18:14:35 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,11 +19,11 @@ void	signal_reset_prompt(int sig)
 {
 	if (sig == SIGINT)
 	{
+		g_signal = SIGINT;
 		rl_replace_line("", 0);
 		write(1, "\n", 1);
 		rl_on_new_line();
 		rl_redisplay();
-		g_exit_code = X_SIG_CTRL_C;
 	}
 }
 
@@ -34,10 +34,10 @@ void	signal_ctrl_c(int sig)
 {
 	if (sig == SIGINT)
 	{
+		g_signal = SIGINT;
 		rl_replace_line("", 0);
 		write(1, "\n", 1);
 		rl_on_new_line();
-		g_exit_code = X_SIG_CTRL_C;
 	}
 }
 
@@ -48,8 +48,8 @@ void	signal_backslash(int sig)
 {
 	if (sig == SIGQUIT)
 	{
+		g_signal = SIGQUIT;
 		write(STDERR_FILENO, "Quit\n", 5);
-		g_exit_code = X_SIG_BACKSLASH;
 	}
 }
 
@@ -61,8 +61,7 @@ void	signal_heredoc(int sig)
 	if (sig == SIGINT)
 	{
 		write(1, "\n", 1);
-		g_exit_code = X_SIG_HEREDOC;
-		exit(g_exit_code);
+		exit(X_SIG_HEREDOC);
 	}
 }
 

--- a/sources/executor/signals/signals.c
+++ b/sources/executor/signals/signals.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/02 14:17:42 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/05/25 20:27:11 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/21 17:37:58 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/sources/expander/expander.c
+++ b/sources/expander/expander.c
@@ -6,14 +6,14 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 11:15:41 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 14:44:00 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:56:35 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 #include "../../includes/libft/lib_vector/vector.h"
 
-static char *expand_arg(char **env, char *arg, size_t i)
+static char *expand_arg(char **env, char *arg, size_t i, t_shell *shell)
 {
 	t_vec	vec_val;
     char *key = NULL;
@@ -33,15 +33,15 @@ static char *expand_arg(char **env, char *arg, size_t i)
 	}
 
 	// Get KEY + VAL
-	arg = skip_multiple_expand_chars(arg, i + 1);
-	key = get_env_key(arg, i);
+	arg = skip_multiple_expand_chars(arg, i + 1, shell);
+	key = get_env_key(arg, i, shell);
 	ft_sleep(PROCESS_SLEEP_TIME);
-	val = get_value_for_key(env, key);
+	val = get_value_for_key(env, key, shell);
 
 	// If env key is expand char
 	if (key[0] == '?')
 	{
-		result = expand_exit_code(arg, key, i);
+		result = expand_exit_code(arg, key, i, shell);
 		ft_vec_push_str(&vec_val, result);		
 		free (result);
 		free (val);
@@ -84,16 +84,14 @@ static char *expand_arg(char **env, char *arg, size_t i)
 	return (ft_vec_to_str(&vec_val));
 }
 
-char	*will_expand(char **env, char *arg)
+char	*will_expand(char **env, char *arg, t_shell *shell)
 {
 	size_t	i;
 	int		expand_count;
 	int		expanded_count;
-	// char	*new_arg;
 
 	expanded_count = 0;
 	expand_count = count_expand(arg);
-	// new_arg = NULL;
 	if (expand_count == 0)
 		return (arg);
 	i = 0;
@@ -103,7 +101,7 @@ char	*will_expand(char **env, char *arg)
 			break ;
 		if (arg[i] == EXPAND_CHAR)
 		{
-			arg = expand_arg(env, arg, i);
+			arg = expand_arg(env, arg, i, shell);
 			expanded_count++;
 			i = 0;
 			continue ;

--- a/sources/expander/expander_utils.c
+++ b/sources/expander/expander_utils.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/23 21:54:16 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 12:43:17 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/21 17:57:05 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,16 +36,16 @@ bool is_arg_key(char *arg, char *key)
 	return (false);
 }
 
-char *expand_exit_code(char *arg, char *key, size_t i)
+char	*expand_exit_code(char *arg, char *key, size_t i, t_shell *shell)
 {
 	char	*exit_code_string;
 	char	*leading_substr;
 	char	*trailing_substr;
 	t_vec	vec_arg;
 
-	key = safe_strjoin("$", key);
+	key = safe_strjoin("$", key, shell);
 	arg = ft_str_remove(arg, key);
-	exit_code_string = ft_itoa(g_exit_code);
+	exit_code_string = ft_itoa(shell->exit_code);
 
 	leading_substr = ft_substr(arg, 0, i);
 	trailing_substr = ft_substr(arg, i, ft_strlen(arg));

--- a/sources/expander/get_env_key.c
+++ b/sources/expander/get_env_key.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/29 22:10:43 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 12:42:09 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/21 17:02:36 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ static bool is_end_env_key(char c)
 	return (false);
 }
 
-char *skip_multiple_expand_chars(char *arg, size_t i)
+char *skip_multiple_expand_chars(char *arg, size_t i, t_shell *shell)
 {
 	int		j;
 	int		k;
@@ -31,7 +31,7 @@ char *skip_multiple_expand_chars(char *arg, size_t i)
 
 	j = i;
 	k = 0;
-	buffer = safe_malloc(sizeof(char *) * ft_strlen(arg));
+	buffer = safe_malloc(sizeof(char *) * ft_strlen(arg), shell);
 	if (arg[j] == EXPAND_CHAR)
 	{
 		while (arg[j])
@@ -52,7 +52,7 @@ char *skip_multiple_expand_chars(char *arg, size_t i)
 	return (arg);
 }
 
-char	*get_env_key(char *arg, size_t i)
+char	*get_env_key(char *arg, size_t i, t_shell *shell)
 {
 	int		j;
 	char	*key;
@@ -62,12 +62,12 @@ char	*get_env_key(char *arg, size_t i)
 		return ("?");
 	if (ft_strlen(arg) == i + 1)
 	{
-		key = safe_strdup_from(arg, i);
+		key = safe_strdup_from(arg, i, shell);
 		key = ft_str_remove_char(key, 0, EXPAND_CHAR);
 		return (key);
 	}
 	j = 0;
-	key = safe_malloc(sizeof(char *) * ft_strlen(arg) + 1);
+	key = safe_malloc(sizeof(char *) * ft_strlen(arg) + 1, shell);
 	while (arg[i])
 	{
 		if (is_end_env_key(arg[i]))

--- a/sources/lexer/lexer.c
+++ b/sources/lexer/lexer.c
@@ -6,24 +6,24 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:13:52 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/14 16:32:07 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:12:51 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-t_token	*token_constructor(char *split_input, int i)
+t_token	*token_constructor(char *split_input, int i, t_shell *shell)
 {
 	t_token	*token;
 
-	token = safe_malloc(sizeof(t_token));
+	token = safe_malloc(sizeof(t_token), shell);
 	if (token == NULL)
 		return (NULL);
 	token->len = ft_strlen(split_input);
-	token->value = safe_strdup(split_input);
+	token->value = safe_strdup(split_input, shell);
 	if (token->value == NULL)
 	{
-		show_error_message(E_MALLOC, C_RED, "safe_strdup token", X_FAILURE);
+		show_error_message(E_MALLOC, shell, "safe_strdup token", X_FAILURE);
 		return (NULL);
 	}
 	token->type = assign_type(token->value);
@@ -61,7 +61,7 @@ static t_token	*tokenize_command(t_token *tokens_head, t_shell *shell)
 	new = NULL;
 	while (split_struct->strings[i])
 	{
-		new = token_constructor(split_struct->strings[i], i);
+		new = token_constructor(split_struct->strings[i], i, shell);
 		if (new == NULL)
 			return (free_split(split_struct), NULL);
 		assign_token(&tokens_head, &current, new);
@@ -87,9 +87,9 @@ int	tokens_builder_manager(t_shell *shell)
 int	shell_lexer(t_shell *shell)
 {
 	if (validate_operators(shell->input) == FAILURE)
-		return (show_error_message(E_OPERATOR, C_RED, "", X_FAILURE));
+		return (show_error_message(E_OPERATOR, shell, "", X_FAILURE));
 	if (validate_quotes(shell) == FAILURE)
-		return (show_error_message(E_QUOTE, C_RED, "", X_FAILURE));
+		return (show_error_message(E_QUOTE, shell, "", X_FAILURE));
 	if (tokens_builder_manager(shell) == SUCCESS)
 		return (print_tokens(shell));
 	return (FAILURE);

--- a/sources/lexer/split/allocate_strings.c
+++ b/sources/lexer/split/allocate_strings.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/07 13:01:10 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 16:24:01 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:18:02 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,14 +28,16 @@ static char	**allocate_substrings(t_split *sp)
 {
 	if (sp->i_buff > 0)
 	{
-		sp->strings[sp->i_str] = safe_strdup(sp->buffer);
+		sp->strings[sp->i_str] = ft_strdup(sp->buffer);
+		if (sp->strings[sp->i_str] == NULL)
+			return (free_split(sp), NULL);
 		sp->i_str++;
 	}
 	clear_buffer(sp);
 	return (sp->strings);
 }
 
-bool	check_operators_substring(t_split *sp)
+static bool	check_operators_substring(t_split *sp)
 {
 	if (check_operator(sp->input[sp->i], sp->input[sp->i + 1]) == 2)
 	{
@@ -59,7 +61,7 @@ bool	check_operators_substring(t_split *sp)
 	return (true);
 }
 
-t_split	*handle_substrings(t_split *sp)
+static t_split	*handle_substrings(t_split *sp, t_shell *shell)
 {
 	while (sp->i < sp->len)
 	{
@@ -76,21 +78,21 @@ t_split	*handle_substrings(t_split *sp)
 		sp->i_buff++;
 		if (sp->i >= BUFF_SIZE - 2 || sp->i_buff >= BUFF_SIZE - 2)
 		{
-			show_error_message(E_OVERFLOW, C_RED, "", X_FAILURE);
+			show_error_message(E_OVERFLOW, shell, "", X_FAILURE);
 			return (NULL);
 		}
 	}
 	return (sp);
 }
 
-char	**allocate_strings_split(t_split *sp)
+char	**allocate_strings_split(t_split *sp, t_shell *shell)
 {
 	sp->i = 0;
 	while (sp->i < sp->len)
 	{
 		sp->i = skip_whitespace(sp);
 		sp->i_buff = 0;
-		sp = handle_substrings(sp);
+		sp = handle_substrings(sp, shell);
 		if (sp == NULL)
 			return (NULL);
 		sp->buffer[sp->i_buff] = 0;

--- a/sources/lexer/split/split.c
+++ b/sources/lexer/split/split.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/05 14:17:27 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/13 16:24:55 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:17:11 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -100,17 +100,17 @@ t_split	*split(t_shell *shell)
 {
 	t_split	*split;
 
-	split = safe_malloc(sizeof(t_split));
+	split = safe_malloc(sizeof(t_split), shell);
 	split = init_split(shell, split);
 	split->count = count_substrings(split);
-	split->strings = safe_calloc(sizeof(char *), (split->count + 1));
+	split->strings = safe_calloc(sizeof(char *), (split->count + 1), shell);
 	if (split->strings == NULL)
 	{
 		free_split(split);
-		show_error_message(E_MALLOC, C_RED, "split", X_FAILURE);
+		show_error_message(E_MALLOC, shell, "split", X_FAILURE);
 		return (NULL);
 	}
-	split->strings = allocate_strings_split(split);
+	split->strings = allocate_strings_split(split, shell);
 	if (split->strings == NULL)
 		return (NULL);
 	return (split);

--- a/sources/lexer/split/split_utils.c
+++ b/sources/lexer/split/split_utils.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/17 15:59:08 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/05/02 15:48:54 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 16:44:45 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 t_split	*init_split(t_shell *shell, t_split *split)
 {
-	split->input = safe_strdup(shell->input);
+	split->input = safe_strdup(shell->input, shell);
 	split->len = ft_strlen(shell->input);
 	split->i = 0;
 	split->i_check = 0;

--- a/sources/minishell.c
+++ b/sources/minishell.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:13:49 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 16:41:40 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:55:06 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,6 @@ static bool	shell_retrieve_command(t_shell *shell)
 	{
 		free(command);
 		free_shell(shell, true);
-		exit_with_message(E_EOF_DESCRIPTOR, RESET_COLOR, EXIT_SUCCESS);
 	}
 	save_command(command, shell);
 	free(command);

--- a/sources/minishell.c
+++ b/sources/minishell.c
@@ -6,13 +6,22 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:13:49 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:55:06 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 18:20:39 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
-int	g_exit_code = 0;
+int	g_signal = 0;
+
+static void	signal_check(t_shell *shell)
+{
+	if (g_signal == SIGINT)
+	{
+		shell->exit_code = 130;
+		g_signal = 0;
+	}
+}
 
 static t_validation	is_valid_input(t_shell *shell)
 {
@@ -42,6 +51,7 @@ static bool	shell_run(t_shell *shell)
 	{
 		handle_signals(PARENT);
 		shell_retrieve_command(shell);
+		signal_check(shell);
 		if (is_valid_input(shell))
 			if (shell_lexer(shell))
 				if (shell_parser(shell))

--- a/sources/parser/parser.c
+++ b/sources/parser/parser.c
@@ -6,47 +6,47 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/11 19:53:12 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 13:33:01 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:20:09 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static t_cmd	*construct_command(t_cmd *cmd, t_parse *p)
+static t_cmd	*construct_command(t_cmd *cmd, t_parse *p, t_shell *shell)
 {
 	if (p->tokens_c->type == COMMAND)
-		cmd->value = safe_strdup(p->tokens_c->value);
+		cmd->value = safe_strdup(p->tokens_c->value, shell);
 	else if (p->tokens_c->type == S_QUOTE || p->tokens_c->type == D_QUOTE)
 	{
-		cmd->value = safe_strdup(p->tokens_c->value);
+		cmd->value = safe_strdup(p->tokens_c->value, shell);
 		if (p->tokens_c->next)
 			p->tokens_c = p->tokens_c->next;
 	}
 	return (cmd);
 }
 
-t_cmd	*build_cmd(t_parse *p)
+t_cmd	*build_cmd(t_parse *p, t_shell *shell)
 {
 	t_cmd	*cmd;
 
 	p->tokens_c = locate_current_token(p);
 	if (p->tokens_c)
 	{
-		cmd = allocate_cmd();
-		cmd = construct_command(cmd, p);
-		cmd = construct_args(cmd, p);
-		cmd = construct_redirects(cmd, p);
+		cmd = allocate_cmd(shell);
+		cmd = construct_command(cmd, p, shell);
+		cmd = construct_args(cmd, p, shell);
+		cmd = construct_redirects(cmd, p, shell);
 		p->current_pipe++;
 		return (cmd);
 	}
 	return (NULL);
 }
 
-bool	build_cmds(t_parse *p)
+bool	build_cmds(t_parse *p, t_shell *shell)
 {
 	while (p->i < p->cmd_count)
 	{
-		p->cmds[p->i] = build_cmd(p);
+		p->cmds[p->i] = build_cmd(p, shell);
 		p->i++;
 	}
 	return (SUCCESS);
@@ -57,10 +57,10 @@ bool	shell_parser(t_shell *shell)
 	t_parse	*p;
 
 	should_print("\n\n========parser========\n", shell->print_output);
-	if (parser_checks(shell->tokens) == FAILURE)
+	if (parser_checks(shell) == FAILURE)
 		return (FAILURE);
 	p = init_parse(shell);
-	build_cmds(p);
+	build_cmds(p, shell);
 	shell->cmd_table->cmds = p->cmds;
 	shell->cmd_table->cmd_count = p->cmd_count;
 	parser_post_process(shell);

--- a/sources/parser/parser_checks.c
+++ b/sources/parser/parser_checks.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/18 21:07:32 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 16:25:21 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:19:55 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,13 +66,13 @@ static bool	check_redirects(t_token *tokens)
 	return (SUCCESS);
 }
 
-bool	parser_checks(t_token *tokens)
+bool	parser_checks(t_shell *shell)
 {
-	if (tokens == NULL)
+	if (shell->tokens == NULL)
 		return (FAILURE);
-	if (check_pipes(tokens) == FAILURE)
-		return (show_error_message(E_PIPE, C_RED, "", X_FAILURE));
-	if (check_redirects(tokens) == FAILURE)
-		return (show_error_message(E_REDIRECT, C_RED, "", X_FAILURE));
+	if (check_pipes(shell->tokens) == FAILURE)
+		return (show_error_message(E_PIPE, shell, "", X_FAILURE));
+	if (check_redirects(shell->tokens) == FAILURE)
+		return (show_error_message(E_REDIRECT, shell, "", X_FAILURE));
 	return (SUCCESS);
 }

--- a/sources/parser/parser_cmd_arguments.c
+++ b/sources/parser/parser_cmd_arguments.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 10:14:19 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 13:31:56 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 18:33:25 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ static int	count_args(t_parse *p)
 	return (count);
 }
 
-static char	**allocate_args(t_parse *p)
+static char	**allocate_args(t_parse *p, t_shell *shell)
 {
 	char	**args;
 	int		arg_count;
@@ -46,7 +46,7 @@ static char	**allocate_args(t_parse *p)
 
 	i = 0;
 	arg_count = count_args(p);
-	args = safe_malloc(sizeof(char *) * (arg_count + 1));
+	args = safe_malloc(sizeof(char *) * (arg_count + 1), shell);
 	while (i <= arg_count)
 	{
 		args[i] = NULL;
@@ -55,22 +55,21 @@ static char	**allocate_args(t_parse *p)
 	return (args);
 }
 
-t_cmd	*construct_args(t_cmd *cmd, t_parse *p)
+t_cmd	*construct_args(t_cmd *cmd, t_parse *p, t_shell *shell)
 {
 	int			i;
 	t_token		*current;
 
 	i = 0;
 	current = p->tokens_c;
-	cmd->args = allocate_args(p);
+	cmd->args = allocate_args(p, shell);
 	if (cmd->args == NULL)
 		return (NULL);
-
 	while (current)
 	{
 		if (is_type_arg(current->type))
 		{
-			cmd->args[i] = safe_strdup(current->value);
+			cmd->args[i] = safe_strdup(current->value, shell);
 			if (cmd->args[i] == NULL)
 			{
 				while (i >= 0)

--- a/sources/parser/parser_post_process.c
+++ b/sources/parser/parser_post_process.c
@@ -6,13 +6,13 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 10:13:21 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 14:19:43 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 18:01:53 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static t_cmd	*process_args(char **env, t_cmd *cmd)
+static t_cmd	*process_args(char **env, t_cmd *cmd, t_shell *shell)
 {
 	int	i;
 
@@ -25,28 +25,28 @@ static t_cmd	*process_args(char **env, t_cmd *cmd)
 		}
 		else if (contains_quote(cmd->args[i]) == D_QUOTE_CHAR)
 		{
-			cmd->args[i] = will_expand(env, cmd->args[i]);
+			cmd->args[i] = will_expand(env, cmd->args[i], shell);
 			cmd->args[i] = new_strip_quotes(cmd->args[i]);
 		}
 		else
-			cmd->args[i] = will_expand(env, cmd->args[i]);
+			cmd->args[i] = will_expand(env, cmd->args[i], shell);
 		i++;
 	}
 	return (cmd);
 }
 
-static t_cmd	*process_cmd(char **env, t_cmd *cmd)
+static t_cmd	*process_cmd(char **env, t_cmd *cmd, t_shell *shell)
 {
 	if (cmd->value == NULL)
 		return (cmd);
 	if (contains_quote(cmd->value) == S_QUOTE_CHAR)
 	{
-		cmd->value = will_expand(env, cmd->value);
+		cmd->value = will_expand(env, cmd->value, shell);
 		cmd->value = new_strip_quotes(cmd->value);
 	}
 	else if (contains_quote(cmd->value) == D_QUOTE_CHAR)
 	{
-		cmd->value = will_expand(env, cmd->value);
+		cmd->value = will_expand(env, cmd->value, shell);
 		cmd->value = new_strip_quotes(cmd->value);
 	}
 	return (cmd);
@@ -61,8 +61,8 @@ int	parser_post_process(t_shell *shell)
 	cmd = shell->cmd_table->cmds[i];
 	while (i < shell->cmd_table->cmd_count)
 	{
-		cmd = process_cmd(shell->envp, cmd);
-		cmd = process_args(shell->envp, cmd);
+		cmd = process_cmd(shell->envp, cmd, shell);
+		cmd = process_args(shell->envp, cmd, shell);
 		i++;
 	}
 	return (0);

--- a/sources/parser/parser_redirects.c
+++ b/sources/parser/parser_redirects.c
@@ -6,18 +6,18 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/21 20:55:56 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 16:33:18 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 16:55:06 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static t_redirect	*construct_redirect_file(t_token *token)
+static t_redirect	*construct_redirect_file(t_token *token, t_shell *shell)
 {
 	t_redirect	*file;
 
 	file = NULL;
-	file = safe_malloc(sizeof(t_redirect));
+	file = safe_malloc(sizeof(t_redirect), shell);
 	if (file == NULL)
 		return (NULL);
 	if (token->next)
@@ -28,14 +28,16 @@ static t_redirect	*construct_redirect_file(t_token *token)
 	return (file);
 }
 
-static t_redirect	*append_redirect(t_redirect *files, t_token *current)
+static t_redirect	*append_redirect(t_redirect *files, t_token *current, \
+						t_shell *shell)
 {
-	files->next = construct_redirect_file(current);
+	files->next = construct_redirect_file(current, shell);
 	files = files->next;
 	return (files);
 }
 
-static t_redirect	*redirects_for_type(t_parse *p, t_token_type type)
+static t_redirect	*redirects_for_type(t_parse *p, t_token_type type, \
+						t_shell *shell)
 {
 	t_redirect	*files;
 	t_redirect	*files_head;
@@ -50,11 +52,11 @@ static t_redirect	*redirects_for_type(t_parse *p, t_token_type type)
 		{
 			if (files == NULL)
 			{
-				files = construct_redirect_file(current);
+				files = construct_redirect_file(current, shell);
 				files_head = files;
 			}
 			else
-				files = append_redirect(files, current);
+				files = append_redirect(files, current, shell);
 		}
 		if (current->type == PIPE)
 			break ;
@@ -63,9 +65,9 @@ static t_redirect	*redirects_for_type(t_parse *p, t_token_type type)
 	return (files_head);
 }
 
-t_cmd	*construct_redirects(t_cmd *cmd, t_parse *p)
+t_cmd	*construct_redirects(t_cmd *cmd, t_parse *p, t_shell *shell)
 {
-	cmd->fd_in = redirects_for_type(p, REDIR_IN);
-	cmd->fd_out = redirects_for_type(p, REDIR_OUT);
+	cmd->fd_in = redirects_for_type(p, REDIR_IN, shell);
+	cmd->fd_out = redirects_for_type(p, REDIR_OUT, shell);
 	return (cmd);
 }

--- a/sources/parser/parser_utils.c
+++ b/sources/parser/parser_utils.c
@@ -6,19 +6,19 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/25 22:22:42 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/14 16:15:03 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 16:47:01 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static t_cmd	**init_cmds(int cmd_count)
+static t_cmd	**init_cmds(int cmd_count, t_shell *shell)
 {
 	t_cmd	**cmds;
 	int		i;
 
 	i = 0;
-	cmds = safe_malloc(sizeof(t_cmd) * (cmd_count + 1));
+	cmds = safe_malloc(sizeof(t_cmd) * (cmd_count + 1), shell);
 	while (i < cmd_count)
 	{
 		cmds[i] = NULL;
@@ -31,21 +31,21 @@ t_parse	*init_parse(t_shell *shell)
 {
 	t_parse	*p;
 
-	p = safe_malloc(sizeof(t_parse));
+	p = safe_malloc(sizeof(t_parse), shell);
 	p->tokens_r = shell->tokens;
 	p->tokens_c = shell->tokens;
 	p->current_pipe = 0;
 	p->cmd_count = count_pipes(shell) + 1;
-	p->cmds = init_cmds(p->cmd_count);
+	p->cmds = init_cmds(p->cmd_count, shell);
 	p->i = 0;
 	return (p);
 }
 
-t_cmd	*allocate_cmd(void)
+t_cmd	*allocate_cmd(t_shell *shell)
 {
 	t_cmd	*cmd;
 
-	cmd = safe_malloc(sizeof(t_cmd));
+	cmd = safe_malloc(sizeof(t_cmd), shell);
 	cmd->value = NULL;
 	cmd->args = NULL;
 	cmd->cmd_and_args = NULL;

--- a/sources/utils/env_utils.c
+++ b/sources/utils/env_utils.c
@@ -6,13 +6,13 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/13 21:19:19 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/13 16:39:06 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:03:54 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static char	*buffer_env_value(char *env_row, char *key, int i)
+static char	*buffer_env_value(char *env_row, char *key, int i, t_shell *shell)
 {
 	char	*value;
 	int		j;
@@ -21,7 +21,7 @@ static char	*buffer_env_value(char *env_row, char *key, int i)
 	i += 1;
 	j = 0;
 	len = ft_strlen(env_row) - ft_strlen(key) + 1;
-	value = safe_malloc(sizeof(char *) * len);
+	value = safe_malloc(sizeof(char *) * len, shell);
 	while (env_row[i])
 	{
 		if (ft_isspace(env_row[i]))
@@ -38,7 +38,7 @@ static char	*buffer_env_value(char *env_row, char *key, int i)
 	Given key e.g. 'KEY=value', get_value_for_key() returns the string value
 	for the corresponding env key.
 */
-char	*get_value_for_key(char **env, char *key)
+char	*get_value_for_key(char **env, char *key, t_shell *shell)
 {
 	int		row_index;
 	int		i;
@@ -50,7 +50,7 @@ char	*get_value_for_key(char **env, char *key)
 	while (env[row_index][i])
 	{
 		if (env[row_index][i] == '=')
-			return (buffer_env_value(env[row_index], key, i));
+			return (buffer_env_value(env[row_index], key, i, shell));
 		i++;
 	}
 	return (NULL);

--- a/sources/utils/error_messages.c
+++ b/sources/utils/error_messages.c
@@ -6,31 +6,31 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/10 17:49:51 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/21 15:07:20 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 18:33:38 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-int	show_error_message(char *error, char *color, char *arg, int exit_code)
+int	show_error_message(char *error, t_shell *shell, char *arg, int exit_code)
 {
-	write(STDERR_FILENO, color, ft_strlen(color));
+	write(STDERR_FILENO, C_RED, ft_strlen(C_RED));
 	write(STDERR_FILENO, "[minishell]: ", 13);
 	write(STDERR_FILENO, error, ft_strlen(error));
 	write(STDERR_FILENO, arg, ft_strlen(arg));
 	write(STDERR_FILENO, RESET_COLOR, ft_strlen(RESET_COLOR));
 	write(STDERR_FILENO, "\n", 1);
-	g_exit_code = exit_code;
+	shell->exit_code = exit_code;
 	return (FAILURE);
 }
 
-int	exit_with_message(char *error, char *color, int exit_code)
+int	exit_with_message(char *error, t_shell *shell, int exit_code)
 {
-	write(STDERR_FILENO, color, ft_strlen(color));
+	write(STDERR_FILENO, C_RED, ft_strlen(C_RED));
 	write(STDERR_FILENO, error, ft_strlen(error));
 	write(STDERR_FILENO, RESET_COLOR, ft_strlen(RESET_COLOR));
 	write(STDERR_FILENO, "\n", 1);
-	g_exit_code = exit_code;
-	exit(g_exit_code);
+	shell->exit_code = exit_code;
+	exit(shell->exit_code);
 	return (FAILURE);
 }

--- a/sources/utils/function_protection.c
+++ b/sources/utils/function_protection.c
@@ -6,27 +6,24 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/29 13:21:05 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/14 15:11:30 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 17:22:58 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/error_messages.h"
 #include "../../includes/minishell.h"
 
-void	*safe_strjoin(const char *s1, const char *s2)
+void	*safe_strjoin(const char *s1, const char *s2, t_shell *shell)
 {
 	void	*ptr;
 
 	ptr = ft_strjoin(s1, s2);
 	if (ptr == NULL)
-	{
-		g_exit_code = EXIT_FAILURE;
-		exit_with_message(E_MALLOC, C_RED, g_exit_code);
-	}
+		exit_with_message(E_MALLOC, shell, EXIT_FAILURE);
 	return (ptr);
 }
 
-void	*safe_malloc(size_t size)
+void	*safe_malloc(size_t size, t_shell *shell)
 {
 	void	*ptr;
 
@@ -35,26 +32,22 @@ void	*safe_malloc(size_t size)
 	if (ptr == NULL)
 	{
 		free (ptr);
-		g_exit_code = EXIT_FAILURE;
-		exit_with_message(E_MALLOC, C_RED, g_exit_code);
+		exit_with_message(E_MALLOC, shell, EXIT_FAILURE);
 	}
 	return (ptr);
 }
 
-void	*safe_calloc(size_t count, size_t size)
+void	*safe_calloc(size_t count, size_t size, t_shell *shell)
 {
 	void	*ptr;
 
 	ptr = ft_calloc(count, size);
 	if (ptr == NULL)
-	{
-		g_exit_code = EXIT_FAILURE;
-		exit_with_message(E_MALLOC, C_RED, g_exit_code);
-	}
+		exit_with_message(E_MALLOC, shell, EXIT_FAILURE);
 	return (ptr);
 }
 
-char	*safe_strdup(char *str)
+char	*safe_strdup(char *str, t_shell *shell)
 {
 	char	*p;
 
@@ -63,22 +56,18 @@ char	*safe_strdup(char *str)
 	p = ft_strdup(str);
 	if (p == NULL)
 	{
-		g_exit_code = EXIT_FAILURE;
-		exit_with_message(E_MALLOC, C_RED, g_exit_code);
+		exit_with_message(E_MALLOC, shell, EXIT_FAILURE);
 		return (NULL);
 	}
 	return (p);
 }
 
-char	*safe_strdup_from(const char *str, int i)
+char	*safe_strdup_from(const char *str, int i, t_shell *shell)
 {
 	char	*p;
 
 	p = ft_strdup_from(str, i);
 	if (p == NULL)
-	{
-		g_exit_code = EXIT_FAILURE;
-		exit_with_message(E_MALLOC, C_RED, g_exit_code);
-	}
+		exit_with_message(E_MALLOC, shell, EXIT_FAILURE);
 	return (p);
 }

--- a/sources/utils/shell_finish.c
+++ b/sources/utils/shell_finish.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/23 16:15:55 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 11:14:53 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/21 17:52:06 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,6 +60,7 @@ static void	free_shell_struct(t_shell *shell)
 		free(shell->builtin_child);
 		shell->builtin_child = NULL;
 	}
+	exit_with_message(E_EOF_DESCRIPTOR, shell, EXIT_SUCCESS);
 	free(shell);
 }
 
@@ -88,7 +89,7 @@ void	shell_finish(t_shell *shell)
 	free_shell(shell, false);
 	if (dup2(shell->original_stdin, STDIN_FILENO) < 0)
 	{
-		show_error_message(E_DUP, C_RED, "", X_FAILURE);
+		show_error_message(E_DUP, shell, "", X_FAILURE);
 		return ;
 	}
 	should_print("\n--------------------End--------------------\n\n", \

--- a/sources/utils/shell_finish.c
+++ b/sources/utils/shell_finish.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/23 16:15:55 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:52:06 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/23 18:25:08 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,7 +82,6 @@ void	free_shell(t_shell *shell, bool close_shell)
 		free_shell_struct(shell);
 }
 
-// free (cmd_path);
 void	shell_finish(t_shell *shell)
 {
 	lexer_finish(shell);

--- a/sources/utils/shell_init.c
+++ b/sources/utils/shell_init.c
@@ -6,33 +6,33 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/14 14:04:02 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/21 15:01:33 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/21 16:57:21 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static char	**alloc_envp(char **envp)
+static char	**alloc_envp(char **envp, t_shell *shell)
 {
 	int		i;
 	char	**copy_envp;
 
 	i = 0;
-	copy_envp = safe_malloc(sizeof(char *) * env_size(envp) + 1);
+	copy_envp = safe_malloc(sizeof(char *) * env_size(envp) + 1, shell);
 	while (envp[i])
 	{
-		copy_envp[i] = safe_strdup(envp[i]);
+		copy_envp[i] = safe_strdup(envp[i], shell);
 		i++;
 	}
 	copy_envp[i] = NULL;
 	return (copy_envp);
 }
 
-static t_cmd_table	*init_cmd_table(void)
+static t_cmd_table	*init_cmd_table(t_shell *shell)
 {
 	t_cmd_table	*cmd_table;
 
-	cmd_table = safe_malloc(sizeof(t_cmd_table));
+	cmd_table = safe_malloc(sizeof(t_cmd_table), shell);
 	cmd_table->cmd_count = 0;
 	cmd_table->cmds = NULL;
 	return (cmd_table);
@@ -42,20 +42,22 @@ bool	save_command(char *command, t_shell *shell)
 {
 	if (command)
 		add_history(command);
-	shell->input = safe_strdup(command);
+	shell->input = safe_strdup(command, shell);
 	return (SUCCESS);
 }
 
 t_shell	*construct_shell(t_shell *shell, char **envp, char **argv)
 {
-	shell = safe_malloc(sizeof(t_shell));
+	shell = malloc(sizeof(t_shell));
+	if (shell == NULL)
+		return (NULL);
+	shell->exit_code = 0;
 	shell->input = NULL;
 	shell->tokens = NULL;
-	shell->cmd_table = init_cmd_table();
-	shell->envp = alloc_envp(envp);
+	shell->cmd_table = init_cmd_table(shell);
+	shell->envp = alloc_envp(envp, shell);
 	shell->original_stdin = dup(STDIN_FILENO);
 	shell->print_output = argv[1] && ft_strncmp(argv[1], PRINT_FLAG, 2) == 0;
-	shell->exit_code = 0;
 	shell = init_main_builtins(shell);
 	shell = init_child_builtins(shell);
 	return (shell);


### PR DESCRIPTION
- fixes #144 
- `exit codes` now stored in `shell` struct
- `global` only takes signals
- exit codes from `builtins` fixed, now gives correct exit codes
- fixed `echo` bug, now exits the childprocess instead of returning (it was still open)