### PR TITLE
feature/#149 echo-cd improvement, minor exit_no_command fix

### DIFF
--- a/includes/error_messages.h
+++ b/includes/error_messages.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/15 20:04:35 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:15:53 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/24 17:34:57 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@
 # define E_CLOSE				"close failure"
 # define E_OPENING_FILE			"could not open file: "
 # define E_DENY					"Permission denied: "
+# define E_NOT_A_DIR			"Not a directory: "
 # define E_CMD_NOT_FOUND		"command not found: "
 # define E_NUMERIC_ERR			"exit: numeric argument required"
 # define E_ARG_ERR				"exit: too many arguments"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:15:00 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/23 22:22:51 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/24 17:45:35 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -323,6 +323,7 @@ int				exec_builtin(t_builtin *table, t_cmd *cmd, \
 
 // cd_utils.c
 void			update_env(t_shell *shell);
+void			cd_error(char *path, t_cmd *cmd, t_shell *shell);
 
 // cd.c
 int				cd(t_cmd *cmd, t_shell *shell);

--- a/sources/builtins/cd.c
+++ b/sources/builtins/cd.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/28 14:31:20 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/24 15:24:33 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/24 17:45:07 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,15 +80,10 @@ int	cd(t_cmd *cmd, t_shell *shell)
 	path = determine_path(cmd, shell);
 	if (path == NULL)
 		return (X_FAILURE);
-	if (access(path, R_OK | X_OK) == -1)
-	{
-		free(path);
-		return (show_error_message(E_DENY, shell, cmd->args[0], 1), 1);
-	}
 	if (chdir(path) == -1)
 	{
-		free(path);
-		return (show_error_message(E_NO_FILE_DIR, shell, cmd->args[0], 1), 1);
+		cd_error(path, cmd, shell);
+		return (free(path), X_FAILURE);
 	}
 	else
 		update_env(shell);

--- a/sources/builtins/cd_utils.c
+++ b/sources/builtins/cd_utils.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/30 16:09:22 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/21 17:24:09 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/24 17:45:16 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,4 +59,14 @@ void	update_env(t_shell *shell)
 	free(oldpwd);
 	free(pwd);
 	free(buff);
+}
+
+void	cd_error(char *path, t_cmd *cmd, t_shell *shell)
+{
+	if (access(path, F_OK && X_OK) == -1)
+		show_error_message(E_NO_FILE_DIR, shell, cmd->args[0], X_FAILURE);
+	else if (access(path, R_OK) == -1)
+		show_error_message(E_DENY, shell, cmd->args[0], X_FAILURE);
+	else
+		show_error_message(E_NOT_A_DIR, shell, cmd->args[0], X_FAILURE);
 }

--- a/sources/builtins/echo.c
+++ b/sources/builtins/echo.c
@@ -6,36 +6,38 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/07 14:45:13 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/24 15:52:20 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/26 13:47:58 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static bool	is_echo_flag(t_cmd *cmd)
+static bool	is_echo_flag(char *arg, bool *flag)
 {
-	if (ft_strncmp(cmd->args[0], "-n", ft_strlen(cmd->args[0])) == 0)
+	size_t	i;
+
+	i = 0;
+	if (arg[i] != '-')
+		return (false);
+	else
+		i++;
+	while (arg[i] == 'n')
+		i++;
+	if (arg[i] == '\0')
+	{
+		*flag = true;
 		return (true);
+	}
 	return (false);
 }
 
-static int	echo_start_index(bool flag)
+static void	print_echo(t_cmd *cmd, int i, bool flag)
 {
-	if (flag)
-		return (1);
-	return (0);
-}
-
-static void	print_echo(t_cmd *cmd, bool flag)
-{
-	int	i;
-
-	i = echo_start_index(flag);
 	while (i < cmd->arg_count)
 	{
 		write(STDOUT_FILENO, cmd->args[i], ft_strlen(cmd->args[i]));
 		if (cmd->args[i + 1])
-			write(1, " ", 2);
+			write(STDOUT_FILENO, " ", 2);
 		i++;
 	}
 	if (flag == false)
@@ -44,18 +46,21 @@ static void	print_echo(t_cmd *cmd, bool flag)
 
 int	echo(t_cmd *cmd, t_shell *shell)
 {
+	int		i;
 	bool	flag;
 
 	(void) shell;
-	flag = is_echo_flag(cmd);
+	i = 0;
+	flag = false;
 	if (cmd->arg_count == 0)
 	{
-		ft_putchar_fd('\n', STDOUT_FILENO);
+		write(STDOUT_FILENO, "\n", 2);
 		exit(EXIT_SUCCESS);
 	}
-	if (flag && cmd->arg_count <= 1)
+	if (cmd->arg_count <= 1 && is_echo_flag(cmd->args[i], &flag))
 		exit(EXIT_SUCCESS);
-	if (cmd->arg_count > 0)
-		print_echo(cmd, flag);
+	while (cmd->args[i] && is_echo_flag(cmd->args[i], &flag))
+		i++;
+	print_echo(cmd, i, flag);
 	exit(EXIT_SUCCESS);
 }

--- a/sources/executor/execute_command/single_command.c
+++ b/sources/executor/execute_command/single_command.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/02 14:28:14 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/23 18:13:44 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/26 13:52:54 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,14 +24,14 @@ static t_validation	assign_out_redirects(t_cmd *cmd, t_shell *shell)
 
 static void	should_exit_no_command(t_cmd *cmd, t_shell *shell)
 {
-	if (ft_strncmp(cmd->cmd_path, CMD_NOT_FOUND_STR, 1) == 0)
-	{
-		show_error_message(E_CMD_NOT_FOUND, shell, cmd->value, X_CMD);
-		exit(shell->exit_code);
-	}
-	else if (cmd->cmd_path == NULL)
+	if (cmd->cmd_path == NULL)
 	{
 		shell->exit_code = 0;
+		exit(shell->exit_code);
+	}
+	else if (ft_strncmp(cmd->cmd_path, CMD_NOT_FOUND_STR, 1) == 0)
+	{
+		show_error_message(E_CMD_NOT_FOUND, shell, cmd->value, X_CMD);
 		exit(shell->exit_code);
 	}
 }

--- a/sources/executor/executor_utils.c
+++ b/sources/executor/executor_utils.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/02/22 19:43:07 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/23 21:26:25 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/26 13:54:59 by robertrinh    ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,7 +55,7 @@ int	prepare_command(t_shell *shell, int i)
 	free_2d_array(env_paths);
 	if (cmd_path == NULL)
 	{
-		cmd->cmd_path = cmd_path;
+		cmd->cmd_path = NULL;
 		return (FAILURE);
 	}
 	cmd->cmd_path = safe_strdup(cmd_path, shell);

--- a/tests/tests.txt
+++ b/tests/tests.txt
@@ -75,8 +75,11 @@ export A=1 NEW=you B=2
 echo "Hello $NEW, copy $A $B"
 cd -
 cd Deskto (invalid dir)
+cd Makefile (a file, no dir)
+cd test (dir with no access rights)
 unset PWD											
 unset HOME PATH SHELL USER PWD TERM ZSH
+echo -n -nnn -n -n -n -n hello
 
 
 === ERROR MESSAGES ===


### PR DESCRIPTION
- fixes #149 
- `echo` now detects multiple `-n`
-  added `Not a directory` error to `cd` builtin
-  minor fix for `should_exit_no_command` when using `ft_strncmp` with a `NULL string` from `cmd->cmd_path`
