### PR TITLE
Feature/#145 split memory fix + norm

### DIFF
--- a/includes/libft/Makefile
+++ b/includes/libft/Makefile
@@ -6,7 +6,7 @@
 #    By: quentinbeukelman <quentinbeukelman@stud      +#+                      #
 #                                                    +#+                       #
 #    Created: 2024/04/15 13:49:48 by quentinbeuk   #+#    #+#                  #
-#    Updated: 2024/06/15 16:20:35 by quentinbeuk   ########   odam.nl          #
+#    Updated: 2024/06/27 13:58:07 by qtrinh        ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 
@@ -56,7 +56,8 @@ LIB_STRING = ft_strlcpy.c \
 			ft_str_remove.c \
 			ft_str_remove_char.c \
 
-LIB_VECTOR = ft_vector.c
+LIB_VECTOR = ft_vector_push.c \
+			ft_vector.c \
 
 LIB_APPLY = ft_strmapi.c \
 			ft_striteri.c \

--- a/includes/libft/lib_string/ft_str_insert.c
+++ b/includes/libft/lib_string/ft_str_insert.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/17 10:13:25 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/15 19:47:32 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 13:59:10 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,35 +44,26 @@ char	*ft_str_insert(char *base, char *insert, int i)
 {
 	char	*buffer;
 	t_vec	vec_base;
+	int		j;
 
-	// Nothing base to insert into
 	if (base == NULL || ft_strlen(base) == 0)
 		return (insert);
-
-	// Init vector
 	if (ft_vec_init(&vec_base, ft_strlen(base)) == false)
 		return (NULL);
-	int j = 0;
+	j = 0;
 	while (j < i)
 	{
 		ft_vec_push(&vec_base, base[j]);
 		j++;
 	}
-
-	// Buffer trailing string
 	buffer = buffer_trailing_string(base, i);
 	if (buffer == NULL)
 	{
 		free (base);
 		return (NULL);
 	}
-
-	// Insert substring
 	ft_vec_push_str(&vec_base, insert);
-
-	// Insert buffer
 	ft_vec_push_str(&vec_base, buffer);
-
 	free (buffer);
 	return (ft_vec_to_str(&vec_base));
 }

--- a/includes/libft/lib_string/ft_str_remove.c
+++ b/includes/libft/lib_string/ft_str_remove.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/17 11:11:34 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/27 14:00:20 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:51:39 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,9 +65,9 @@ char	*insert_buffer(char *base_input, char *buffer, int i)
  * Removes the first occurrence of the substring `remove` from `base_input` 
  * and returns the resulting string. ft_str_remove uses vectors.
  *
- * @param base_input The original string from which the substring will be removed.
+ * @param base_input The original string which the substring will be removed.
  * @param remove The substring to be removed from the original string.
- * @return The modified string with the substring removed, or NULL if an error occurs.
+ * @return Modified string with removed substring, or NULL if an error occurs.
  */
 char	*ft_str_remove(char *base_input, const char *remove)
 {
@@ -77,6 +77,7 @@ char	*ft_str_remove(char *base_input, const char *remove)
 	char	*leading_substr;
 	char	*trailing_substr;
 	t_vec	vec;
+	// ! Norm: Too many variables declarations in a function, 5 max
 
 	needle = ft_strnstr(base_input, remove, ft_strlen(base_input));
 	if (needle == NULL)

--- a/includes/libft/lib_string/ft_str_remove.c
+++ b/includes/libft/lib_string/ft_str_remove.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/17 11:11:34 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 12:41:18 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 14:00:20 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,6 @@ char	*insert_buffer(char *base_input, char *buffer, int i)
 	return (base_input);
 }
 
-
 /**
  * Removes the first occurrence of the substring `remove` from `base_input` 
  * and returns the resulting string. ft_str_remove uses vectors.
@@ -79,39 +78,26 @@ char	*ft_str_remove(char *base_input, const char *remove)
 	char	*trailing_substr;
 	t_vec	vec;
 
-	// Locate remove in base input
 	needle = ft_strnstr(base_input, remove, ft_strlen(base_input));
 	if (needle == NULL)
 		return (NULL);
 	i = locate_substring(base_input, needle);
 	remove_len = ft_strlen(remove);
-
-	// If base is remove, return empty string
 	if (ft_strncmp(base_input, remove, ft_strlen(base_input)) == 0)
 		return ("");
-
-	// Init vector
 	if (ft_vec_init(&vec, ft_strlen(base_input)) == false)
 		return (NULL);
-	
-	// Buffer leading substring
 	leading_substr = ft_substr(base_input, 0, i);
 	if (leading_substr == NULL)
 		return (NULL);
-
 	ft_vec_push_str(&vec, leading_substr);
 	free (leading_substr);
-
-	// If no trailing characters, return modified base
 	if ((size_t)(i + remove_len) == ft_strlen(base_input))
 		return (ft_vec_to_str(&vec));
-
-	// Buffer leading substring
 	trailing_substr = buffer_trailing_string(base_input, remove_len, i);
 	if (trailing_substr == NULL)
 		return (NULL);
 	ft_vec_push_str(&vec, trailing_substr);
 	free (trailing_substr);
-	
 	return (ft_vec_to_str(&vec));
 }

--- a/includes/libft/lib_string/ft_str_remove_char.c
+++ b/includes/libft/lib_string/ft_str_remove_char.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/04 19:56:47 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 11:21:19 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 14:29:48 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,13 +30,12 @@ static bool	buffer_trailing_string(char *base_input, t_vec *vec, \
 	return (true);
 }
 
-static bool insert_buffer(char *base_input, unsigned int i, t_vec *vec, \
+static bool	insert_buffer(char *base_input, unsigned int i, t_vec *vec, \
 	t_vec *vec_buffer)
 {
-	unsigned int j;
-	unsigned int k;
+	unsigned int	j;
+	unsigned int	k;
 
-	// Fill vec with base_input until the position before the character to remove
 	j = 0;
 	while (j < i)
 	{
@@ -44,8 +43,6 @@ static bool insert_buffer(char *base_input, unsigned int i, t_vec *vec, \
 			return (false);
 		j++;
 	}
-
-	// Add buffer after the character to remove
 	k = 0;
 	while (k < vec_buffer->len)
 	{
@@ -53,11 +50,8 @@ static bool insert_buffer(char *base_input, unsigned int i, t_vec *vec, \
 			return (false);
 		k++;
 	}
-
-	// Null-terminate the vector
 	if (ft_vec_push(vec, '\0') == false)
 		return (false);
-
 	return (true);
 }
 
@@ -75,30 +69,20 @@ static bool insert_buffer(char *base_input, unsigned int i, t_vec *vec, \
  */
 char	*ft_str_remove_char(char *str, int i, char c)
 {
-	t_vec 	vec;
-	t_vec 	vec_buffer;
+	t_vec	vec;
+	t_vec	vec_buffer;
 
-	// Check first char is quote
 	if (str[i] != c)
 		return (str);
-
-	// Init vec
 	if (!ft_vec_init(&vec, ft_strlen(str) + 1))
 		return (NULL);
 	if (!ft_vec_init(&vec_buffer, ft_strlen(str) + 1))
 		return (NULL);
-
-	// Buffer chars after quote
 	if (buffer_trailing_string(str, &vec_buffer, i) == false)
 		return (NULL);
-
-	// Insert buffer back into the vector
 	if (insert_buffer(str, i, &vec, &vec_buffer) == false)
 		return (NULL);
-	
 	if (vec_buffer.data)
 		ft_vec_free(&vec_buffer);
-
-	// Get the final string and free the main vector
 	return (ft_vec_to_str(&vec));
 }

--- a/includes/libft/lib_vector/ft_vector.c
+++ b/includes/libft/lib_vector/ft_vector.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/06/15 12:37:13 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 11:22:55 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 14:03:56 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,6 @@ void	ft_vec_free(t_vec *v)
 			free(v->data);
 			v->data = NULL;
 		}
-		// free(v);
 	}
 }
 
@@ -40,7 +39,7 @@ void	ft_vec_free(t_vec *v)
  * 
  * Return: true if initialization is successful, false otherwise.
 */
-bool	ft_vec_init(t_vec *v, unsigned int size) 
+bool	ft_vec_init(t_vec *v, unsigned int size)
 {
 	v->data = malloc(sizeof(char) * size);
 	if (!v->data)
@@ -61,94 +60,16 @@ bool	ft_vec_init(t_vec *v, unsigned int size)
  * 
  * Return: true if resizing is successful, false otherwise.
 */
-bool	ft_vec_resize(t_vec *v) 
+bool	ft_vec_resize(t_vec *v)
 {
-	char *tmp;
+	char	*tmp;
 
 	tmp = malloc(sizeof(char) * (v->capacity * 2));
-	if (!tmp) 
+	if (!tmp)
 		return (false);
-	ft_memcpy(tmp, v->data,  v->len);
+	ft_memcpy(tmp, v->data, v->len);
 	free(v->data);
 	v->data = tmp;
 	v->capacity *= 2;
 	return (true);
-}
-
-/**
- * ft_vec_push - Adds a character to the end of the vector.
- * @v: The vector to which the character will be added.
- * @c: The character to add.
- * 
- * This function adds the specified character to the end of the vector. If
- * the vector is full, it first resizes the vector by doubling its capacity.
- * If the resize operation fails, the function returns false.
- * 
- * Return: true if the character is successfully added, false otherwise.
-*/
-bool	ft_vec_push(t_vec *v, char c) 
-{
-	if (v->len == v->capacity) 
-	{
-		if (!ft_vec_resize(v))
-			return (false);
-	}
-	v->data[v->len] = c;
-	v->len++;
-	return (true);
-}
-
-/**
- * ft_vec_push_str - Adds a null-terminated string to the end of the vector.
- * @v: The vector to which the string will be added.
- * @str: The null-terminated string to add.
- * 
- * This function appends the specified string to the end of the vector. If
- * the vector does not have enough capacity to accommodate the new string,
- * it resizes the vector by doubling its capacity until there is enough space.
- * If the resize operation fails, the function returns false.
- * 
- * Return: true if the string is successfully added, false otherwise.
-*/
-bool ft_vec_push_str(t_vec *v, const char *str)
-{
-    size_t	str_len; 
-	
-	str_len = strlen(str);
-    while (v->len + str_len > v->capacity)
-	{
-        if (ft_vec_resize(v) == false)
-            return (false);
-    }
-    ft_memcpy(v->data + v->len, str, str_len);
-    v->len += str_len;
-    return (true);
-}
-
-
-/**
- * ft_vec_to_str - Converts the vector to a null-terminated string.
- * @v: The vector to be converted.
- * 
- * This function adds a null terminator to the end of the vector data,
- * allocates a new array to store the null-terminated string, copies the
- * vector data to the new array, and frees the old data array within the
- * vector. If any memory allocation fails, the function returns NULL.
- * 
- * Return: A pointer to the newly allocated null-terminated string, or NULL
- * if memory allocation fails.
-*/
-char	*ft_vec_to_str(t_vec *v) 
-{
-	char	*tmp;
-
-	if (!ft_vec_push(v, '\0')) 
-		return (NULL);
-	tmp = malloc(sizeof(char) * v->len);
-	if (!tmp)
-		return (NULL);
-	ft_memcpy(tmp, v->data, v->len);
-	free(v->data);
-	v->data = tmp;
-	return (tmp);
 }

--- a/includes/libft/lib_vector/ft_vector_push.c
+++ b/includes/libft/lib_vector/ft_vector_push.c
@@ -1,0 +1,90 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   ft_vector_push.c                                   :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2024/06/27 13:57:03 by qtrinh        #+#    #+#                 */
+/*   Updated: 2024/06/27 13:58:33 by qtrinh        ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "vector.h"
+
+/**
+ * ft_vec_push - Adds a character to the end of the vector.
+ * @v: The vector to which the character will be added.
+ * @c: The character to add.
+ * 
+ * This function adds the specified character to the end of the vector. If
+ * the vector is full, it first resizes the vector by doubling its capacity.
+ * If the resize operation fails, the function returns false.
+ * 
+ * Return: true if the character is successfully added, false otherwise.
+*/
+bool	ft_vec_push(t_vec *v, char c)
+{
+	if (v->len == v->capacity)
+	{
+		if (!ft_vec_resize(v))
+			return (false);
+	}
+	v->data[v->len] = c;
+	v->len++;
+	return (true);
+}
+
+/**
+ * ft_vec_push_str - Adds a null-terminated string to the end of the vector.
+ * @v: The vector to which the string will be added.
+ * @str: The null-terminated string to add.
+ * 
+ * This function appends the specified string to the end of the vector. If
+ * the vector does not have enough capacity to accommodate the new string,
+ * it resizes the vector by doubling its capacity until there is enough space.
+ * If the resize operation fails, the function returns false.
+ * 
+ * Return: true if the string is successfully added, false otherwise.
+*/
+bool	ft_vec_push_str(t_vec *v, const char *str)
+{
+	size_t	str_len;
+
+	str_len = ft_strlen(str);
+	while (v->len + str_len > v->capacity)
+	{
+		if (ft_vec_resize(v) == false)
+			return (false);
+	}
+	ft_memcpy(v->data + v->len, str, str_len);
+	v->len += str_len;
+	return (true);
+}
+
+/**
+ * ft_vec_to_str - Converts the vector to a null-terminated string.
+ * @v: The vector to be converted.
+ * 
+ * This function adds a null terminator to the end of the vector data,
+ * allocates a new array to store the null-terminated string, copies the
+ * vector data to the new array, and frees the old data array within the
+ * vector. If any memory allocation fails, the function returns NULL.
+ * 
+ * Return: A pointer to the newly allocated null-terminated string, or NULL
+ * if memory allocation fails.
+*/
+char	*ft_vec_to_str(t_vec *v)
+{
+	char	*tmp;
+
+	if (!ft_vec_push(v, '\0'))
+		return (NULL);
+	tmp = malloc(sizeof(char) * v->len);
+	if (!tmp)
+		return (NULL);
+	ft_memcpy(tmp, v->data, v->len);
+	free(v->data);
+	v->data = tmp;
+	return (tmp);
+}

--- a/includes/libft/lib_vector/vector.h
+++ b/includes/libft/lib_vector/vector.h
@@ -6,19 +6,20 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/06/15 12:38:45 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/16 11:21:22 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 13:53:37 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef VECTOR_H
 # define VECTOR_H
 
-#include "../includes/libft.h"
+# include "../includes/libft.h"
 
-typedef struct s_vec {
-	char *data;
-	unsigned int len;
-	unsigned int capacity;
+typedef struct s_vec
+{
+	char			*data;
+	unsigned int	len;
+	unsigned int	capacity;
 }	t_vec;
 
 // ft_vector.c

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:15:00 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/24 17:45:35 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/27 13:51:07 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -122,7 +122,7 @@ typedef struct s_split
 	int			i_buff;
 	int			i_str;
 	int			count;
-	char		buffer[BUFF_SIZE];
+	char		*buffer;
 	char		*input;
 	char		**strings;
 }	t_split;
@@ -169,10 +169,11 @@ typedef struct s_cmd_table
 }	t_cmd_table;
 
 typedef struct s_builtin \
-	t_builtin;
+		t_builtin;
 
 typedef struct s_shell
 {
+	t_split				*split;
 	t_token				*tokens;
 	t_cmd_table			*cmd_table;
 	char				**envp;
@@ -185,6 +186,12 @@ typedef struct s_shell
 	t_builtin			*builtin_main;
 	t_builtin			*builtin_child;
 }	t_shell;
+
+typedef struct s_builtin
+{
+	char	*name;
+	int		(*function)(t_cmd*, t_shell*);
+}	t_builtin;
 
 typedef struct s_parse
 {
@@ -204,9 +211,9 @@ typedef struct s_in_files
 
 typedef struct s_cmd_data
 {
-    t_cmd 		*cmd;
-    t_shell 	*shell;
-    t_in_files 	*ins;
+	t_cmd		*cmd;
+	t_shell		*shell;
+	t_in_files	*ins;
 }	t_cmd_data;
 
 //===============================================================: Main
@@ -257,7 +264,6 @@ int				skip_whitespace(t_split *sp);
 int				check_operator(char c1, char c2);
 
 // split.c
-void			free_split(t_split *sp);
 t_split			*split(t_shell *shell);
 
 //===============================================================: Parser
@@ -308,11 +314,6 @@ int				prepare_command(t_shell *shell, int i);
 int				shell_execute(t_shell *shell);
 
 // ----------------------------------- executor/builtins
-typedef struct s_builtin
-{
-	char	*name;
-	int		(*function)(t_cmd*, t_shell*);
-}	t_builtin;
 
 // builtins.c
 t_shell			*init_main_builtins(t_shell *shell);
@@ -461,6 +462,7 @@ void			free_cmd(t_cmd *cmd);
 void			free_2d_array(char **array);
 void			free_tokens(t_token *token);
 void			free_cmd(t_cmd *cmd);
+void			free_split(t_split *split);
 
 // shell_finish.c
 void			free_shell(t_shell *shell, bool will_exit);

--- a/sources/expander/expander.c
+++ b/sources/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 11:15:41 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:56:35 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:29:22 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ static char *expand_arg(char **env, char *arg, size_t i, t_shell *shell)
 	// Get KEY + VAL
 	arg = skip_multiple_expand_chars(arg, i + 1, shell);
 	key = get_env_key(arg, i, shell);
-	ft_sleep(PROCESS_SLEEP_TIME);
+	// ft_sleep(PROCESS_SLEEP_TIME);
 	val = get_value_for_key(env, key, shell);
 
 	// If env key is expand char
@@ -45,7 +45,6 @@ static char *expand_arg(char **env, char *arg, size_t i, t_shell *shell)
 		ft_vec_push_str(&vec_val, result);		
 		free (result);
 		free (val);
-		free (arg);
 		return (ft_vec_to_str(&vec_val));
 	}
 
@@ -80,7 +79,6 @@ static char *expand_arg(char **env, char *arg, size_t i, t_shell *shell)
 	// Result
 	ft_vec_push_str(&vec_val, new_result);
 	free (new_result);
-	free (arg);
 	return (ft_vec_to_str(&vec_val));
 }
 

--- a/sources/expander/expander.c
+++ b/sources/expander/expander.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 11:15:41 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/27 14:29:22 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:49:30 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,8 @@ static char *expand_arg(char **env, char *arg, size_t i, t_shell *shell)
     char *result = NULL;
     char *new_key = NULL;
     char *new_result = NULL;
-
+	// ! Norm: Too many variables declarations in a function, 5 max
+	
 	if (ft_vec_init(&vec_val, ft_strlen(arg)) == false)
 		return (NULL);
 

--- a/sources/expander/expander_utils.c
+++ b/sources/expander/expander_utils.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/04/23 21:54:16 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:57:05 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:39:51 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,9 +29,9 @@ int	count_expand(char *arg)
 	return (count);
 }
 
-bool is_arg_key(char *arg, char *key)
+bool	is_arg_key(char *arg, char *key)
 {
-	if (ft_strncmp(arg, key, (ft_strlen(key) + ft_strlen(arg)))  == 0)
+	if (ft_strncmp(arg, key, (ft_strlen(key) + ft_strlen(arg))) == 0)
 		return (true);
 	return (false);
 }
@@ -46,19 +46,15 @@ char	*expand_exit_code(char *arg, char *key, size_t i, t_shell *shell)
 	key = safe_strjoin("$", key, shell);
 	arg = ft_str_remove(arg, key);
 	exit_code_string = ft_itoa(shell->exit_code);
-
 	leading_substr = ft_substr(arg, 0, i);
 	trailing_substr = ft_substr(arg, i, ft_strlen(arg));
-
 	ft_vec_init(&vec_arg, ft_strlen(arg) + ft_strlen(exit_code_string) + 1);
 	ft_vec_push_str(&vec_arg, leading_substr);
 	ft_vec_push_str(&vec_arg, exit_code_string);
 	ft_vec_push_str(&vec_arg, trailing_substr);
-	
 	free (key);
 	free (exit_code_string);
 	free (leading_substr);
 	free (trailing_substr);
-
 	return (ft_vec_to_str(&vec_arg));
 }

--- a/sources/expander/get_env_key.c
+++ b/sources/expander/get_env_key.c
@@ -6,16 +6,16 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/29 22:10:43 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 17:02:36 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:39:12 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static bool is_end_env_key(char c)
+static bool	is_end_env_key(char c)
 {
 	if (ft_isspace(c))
-		return (true); 
+		return (true);
 	else if (c == D_QUOTE_CHAR || c == S_QUOTE_CHAR)
 		return (true);
 	else if (c == EXPAND_CHAR)
@@ -23,7 +23,7 @@ static bool is_end_env_key(char c)
 	return (false);
 }
 
-char *skip_multiple_expand_chars(char *arg, size_t i, t_shell *shell)
+char	*skip_multiple_expand_chars(char *arg, size_t i, t_shell *shell)
 {
 	int		j;
 	int		k;

--- a/sources/lexer/lexer.c
+++ b/sources/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/12/03 13:13:52 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/26 23:07:43 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 13:11:33 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ t_token	*token_constructor(char *split_input, int i, t_shell *shell)
 	if (token == NULL)
 		return (NULL);
 	token->len = ft_strlen(split_input);
-	token->value = safe_strdup(split_input);
+	token->value = split_input;
 	if (token->value == NULL)
 	{
 		show_error_message(E_MALLOC, shell, "safe_strdup token", X_FAILURE);
@@ -67,7 +67,7 @@ static t_token	*tokenize_command(t_token *tokens_head, t_shell *shell)
 		assign_token(&tokens_head, &current, new);
 		i++;
 	}
-	free_split(split_struct);
+	shell->split = split_struct;
 	return (tokens_head);
 }
 

--- a/sources/lexer/split/allocate_strings.c
+++ b/sources/lexer/split/allocate_strings.c
@@ -6,34 +6,21 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/07 13:01:10 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/26 23:06:09 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 12:50:56 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
 
-static void	clear_buffer(t_split *sp)
-{
-	int	i;
-
-	i = 0;
-	while (i < BUFF_SIZE)
-	{
-		sp->buffer[i] = 0;
-		i++;
-	}
-}
-
 static char	**allocate_substrings(t_split *sp)
 {
 	if (sp->i_buff > 0)
 	{
-		sp->strings[sp->i_str] = ft_strdup(sp->buffer);
+		sp->strings[sp->i_str] = sp->buffer;
 		if (sp->strings[sp->i_str] == NULL)
 			return (free_split(sp), NULL);
 		sp->i_str++;
 	}
-	clear_buffer(sp);
 	return (sp->strings);
 }
 
@@ -90,6 +77,13 @@ char	**allocate_strings_split(t_split *sp, t_shell *shell)
 	sp->i = 0;
 	while (sp->i < sp->len)
 	{
+		sp->buffer = safe_calloc(sizeof(char), BUFF_SIZE, shell);
+		if (sp->buffer == NULL)
+		{
+			free_split(sp);
+			show_error_message(E_MALLOC, shell, "split", X_FAILURE);
+			return (NULL);
+		}
 		sp->i = skip_whitespace(sp);
 		sp->i_buff = 0;
 		sp = handle_substrings(sp, shell);

--- a/sources/lexer/split/split.c
+++ b/sources/lexer/split/split.c
@@ -3,32 +3,14 @@
 /*                                                        ::::::::            */
 /*   split.c                                            :+:    :+:            */
 /*                                                     +:+                    */
-/*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
+/*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2024/01/05 14:17:27 by qbeukelm      #+#    #+#                 */
-/*   Updated: 2024/06/26 23:08:02 by quentinbeuk   ########   odam.nl         */
+/*   Created: 2024/06/27 12:23:45 by qtrinh        #+#    #+#                 */
+/*   Updated: 2024/06/27 14:34:29 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../includes/minishell.h"
-
-void	free_split(t_split *sp)
-{
-	if (sp == NULL)
-		return ;
-	if (sp->input)
-	{
-		free(sp->input);
-		sp->input = NULL;
-	}
-	if (sp->strings)
-	{
-		free(sp->strings);
-		sp->strings = NULL;
-	}
-	free(sp);
-	sp = NULL;
-}
 
 static int	index_next_quote(t_split *sp, int quote_type)
 {
@@ -94,6 +76,7 @@ t_split	*split(t_shell *shell)
 	split = safe_malloc(sizeof(t_split), shell);
 	split = init_split(shell, split);
 	split->count = count_substrings(split);
+	split->strings = NULL;
 	split->strings = safe_calloc(sizeof(char *), (split->count + 1), shell);
 	if (split->strings == NULL)
 	{

--- a/sources/lexer/split/split_utils.c
+++ b/sources/lexer/split/split_utils.c
@@ -6,7 +6,7 @@
 /*   By: qtrinh <qtrinh@student.codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/17 15:59:08 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/26 23:06:46 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 12:13:42 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 t_split	*init_split(t_shell *shell, t_split *split)
 {
-	split->input = safe_strdup(shell->input, shell);
+	split->input = shell->input;
 	split->len = ft_strlen(shell->input);
 	split->i = 0;
 	split->i_check = 0;

--- a/sources/parser/parser.c
+++ b/sources/parser/parser.c
@@ -6,19 +6,19 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/01/11 19:53:12 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/26 23:07:03 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 13:15:38 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
 
-static t_cmd	*construct_command(t_cmd *cmd, t_parse *p, t_shell *shell)
+static t_cmd	*construct_command(t_cmd *cmd, t_parse *p)
 {
 	if (p->tokens_c->type == COMMAND)
-		cmd->value = safe_strdup(p->tokens_c->value, shell);
+		cmd->value = p->tokens_c->value;
 	else if (p->tokens_c->type == S_QUOTE || p->tokens_c->type == D_QUOTE)
 	{
-		cmd->value = safe_strdup(p->tokens_c->value, shell);
+		cmd->value = p->tokens_c->value;
 		if (p->tokens_c->next)
 			p->tokens_c = p->tokens_c->next;
 	}
@@ -33,7 +33,7 @@ t_cmd	*build_cmd(t_parse *p, t_shell *shell)
 	if (p->tokens_c)
 	{
 		cmd = allocate_cmd(shell);
-		cmd = construct_command(cmd, p, shell);
+		cmd = construct_command(cmd, p);
 		cmd = construct_args(cmd, p, shell);
 		cmd = construct_redirects(cmd, p, shell);
 		p->current_pipe++;

--- a/sources/parser/parser_cmd_arguments.c
+++ b/sources/parser/parser_cmd_arguments.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 10:14:19 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/27 13:35:50 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:40:17 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ t_cmd	*construct_args(t_cmd *cmd, t_parse *p, t_shell *shell)
 		{
 			cmd->args[i] = current->value;
 			if (cmd->args[i] == NULL)
-				return(free(cmd->args), NULL);
+				return (free(cmd->args), NULL);
 			i++;
 		}
 		if (current->type == PIPE)

--- a/sources/parser/parser_cmd_arguments.c
+++ b/sources/parser/parser_cmd_arguments.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 10:14:19 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/26 23:07:17 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 13:35:50 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,13 +69,9 @@ t_cmd	*construct_args(t_cmd *cmd, t_parse *p, t_shell *shell)
 	{
 		if (is_type_arg(current->type))
 		{
-			cmd->args[i] = safe_strdup(current->value, shell);
+			cmd->args[i] = current->value;
 			if (cmd->args[i] == NULL)
-			{
-				while (i > 0)
-					free(cmd->args[--i]);
-				return (free(cmd->args), NULL);
-			}
+				return(free(cmd->args), NULL);
 			i++;
 		}
 		if (current->type == PIPE)

--- a/sources/parser/parser_post_process.c
+++ b/sources/parser/parser_post_process.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/03/16 10:13:21 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/21 18:01:53 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:29:36 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,9 +20,7 @@ static t_cmd	*process_args(char **env, t_cmd *cmd, t_shell *shell)
 	while (i < cmd->arg_count)
 	{
 		if (contains_quote(cmd->args[i]) == S_QUOTE_CHAR)
-		{
 			cmd->args[i] = new_strip_quotes(cmd->args[i]);
-		}
 		else if (contains_quote(cmd->args[i]) == D_QUOTE_CHAR)
 		{
 			cmd->args[i] = will_expand(env, cmd->args[i], shell);

--- a/sources/utils/shell_finish.c
+++ b/sources/utils/shell_finish.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/23 16:15:55 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/23 18:25:08 by robertrinh    ########   odam.nl         */
+/*   Updated: 2024/06/27 13:12:11 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,6 +66,11 @@ static void	free_shell_struct(t_shell *shell)
 
 void	free_shell(t_shell *shell, bool close_shell)
 {
+	if (shell->split)
+	{
+		free_split(shell->split);
+		shell->split = NULL;
+	}
 	if (shell->tokens)
 	{
 		free_tokens(shell->tokens);

--- a/sources/utils/shell_finish_cmd.c
+++ b/sources/utils/shell_finish_cmd.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/06/01 16:00:19 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/27 14:22:11 by qtrinh        ########   odam.nl         */
+/*   Updated: 2024/06/27 14:40:07 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,11 +67,6 @@ void	free_cmd(t_cmd *cmd)
 		free(cmd->cmd_path);
 		cmd->cmd_path = NULL;
 	}
-	// if (cmd->value)
-	// {
-	// 	free(cmd->value);
-	// 	cmd->value = NULL;
-	// }
 	free(cmd);
 	cmd = NULL;
 }

--- a/sources/utils/shell_finish_cmd.c
+++ b/sources/utils/shell_finish_cmd.c
@@ -6,7 +6,7 @@
 /*   By: qbeukelm <qbeukelm@student.42.fr>            +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/06/01 16:00:19 by qtrinh        #+#    #+#                 */
-/*   Updated: 2024/06/22 01:29:05 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 14:22:11 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,8 +24,10 @@ static void	free_cmd_fd(t_redirect *head)
 	}
 }
 
-static void	free_args_format(t_cmd *cmd, int i)
+static void	free_args_format(t_cmd *cmd)
 {
+	int	i;
+
 	i = 0;
 	while (i <= cmd->arg_count)
 	{
@@ -42,25 +44,13 @@ static void	free_args_format(t_cmd *cmd, int i)
 
 static void	free_args_format_cmd(t_cmd *cmd)
 {
-	int	i;
-
 	if (cmd->args)
 	{
-		i = 0;
-		while (i <= cmd->arg_count)
-		{
-			if (cmd->args[i])
-			{
-				free(cmd->args[i]);
-				cmd->args[i] = NULL;
-			}
-			i++;
-		}
 		free(cmd->args);
 		cmd->args = NULL;
 	}
 	if (cmd->cmd_and_args)
-		free_args_format(cmd, i);
+		free_args_format(cmd);
 }
 
 void	free_cmd(t_cmd *cmd)
@@ -77,11 +67,11 @@ void	free_cmd(t_cmd *cmd)
 		free(cmd->cmd_path);
 		cmd->cmd_path = NULL;
 	}
-	if (cmd->value)
-	{
-		free(cmd->value);
-		cmd->value = NULL;
-	}
+	// if (cmd->value)
+	// {
+	// 	free(cmd->value);
+	// 	cmd->value = NULL;
+	// }
 	free(cmd);
 	cmd = NULL;
 }

--- a/sources/utils/shell_finish_utils.c
+++ b/sources/utils/shell_finish_utils.c
@@ -6,7 +6,7 @@
 /*   By: quentinbeukelman <quentinbeukelman@stud      +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2024/05/23 16:15:41 by quentinbeuk   #+#    #+#                 */
-/*   Updated: 2024/06/22 01:46:57 by quentinbeuk   ########   odam.nl         */
+/*   Updated: 2024/06/27 13:13:41 by qtrinh        ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,17 @@ void	free_tokens(t_token *token)
 		free_token(token);
 		token = next;
 	}
+}
+
+void	free_split(t_split *split)
+{
+	if (split)
+	{
+		free_2d_array(split->strings);
+		split->strings = NULL;
+	}
+	free(split);
+	split = NULL;
 }
 
 void	free_2d_array(char **array)


### PR DESCRIPTION
- refactured `split` regarding memory
- deleted `safe_strdup` in several places to lesson memory management
- deteled `free` functions as result of deleting `safe_strdup`
- norm fixes and comments